### PR TITLE
Change to 1-based positions

### DIFF
--- a/src/main/resources/avro/ga4gh.avdl
+++ b/src/main/resources/avro/ga4gh.avdl
@@ -10,7 +10,6 @@ record GA4GHReferenceSequence {
   union { null, string } uri = null;
 }
 
-// Test
 record GA4GHReadGroup {
   union { null, string } date = null;
   union { null, string } description = null;


### PR DESCRIPTION
While I personally like 0-based for positions, switching our schema to use them results in a ton of confusion when integrating with other code bases. I experienced this when integrating with dbsnp/snpedia. It's too easy to think a read means something different because of that small off by one error.
