### PR TITLE
every Read must belong to exactly one Readset

### DIFF
--- a/src/main/resources/avro/ga4gh.avdl
+++ b/src/main/resources/avro/ga4gh.avdl
@@ -6,7 +6,7 @@ record GA4GHReferenceSequence {
   union { null, long } length = null;
   union { null, string } md5checksum = null;
   union { null, string } name = null;
-  union { null, string } species = null;
+  union { null, string } species = null;    // an ID from http://www.ncbi.nlm.nih.gov/taxonomy (e.g. "9606"=human)
   union { null, string } uri = null;
 }
 


### PR DESCRIPTION
Enforce read/readset relationship, by requiring that every Read belong to exactly one Readset.
