### PR TITLE
Initial attempt at specifying 2 method definitions - read search and readset search.

### DIFF
--- a/src/main/resources/avro/methods.avdl
+++ b/src/main/resources/avro/methods.avdl
@@ -17,7 +17,7 @@ record GASearchReadsRequest {
   // specified, this defaults to 0.
   union { null, long } start_position = null;
 
-  // The end position (1-based, inclusive) of this query. If a contig is
+  // The end position (0-based, inclusive) of this query. If a contig is
   // specified, this defaults to the contig's length.
   union { null, long } end_position = null;
 


### PR DESCRIPTION
@massie - I tried to follow the beacon.avdl pattern. Hopefully this is at least semi-correct avro.
