### PR TITLE
Structured CIGAR; added barebone GADataSet

### DIFF
--- a/src/main/resources/avro/ga4gh.avdl
+++ b/src/main/resources/avro/ga4gh.avdl
@@ -70,14 +70,14 @@ record GAReadSet {
 
 enum GACigarOperation {
     ALIGNMENT_MATCH,   // M
-	INSERTION,         // I
-	DELETION,          // D
-	REFERENCE_SKIP,    // N
-	SOFT_CLIPPING,     // S
-	HARD_CLIPPING,     // H
-	PADDING,           // P
-	SEQUENCE_MATCH,    // =
-	SEQUENCE_MISMATCH  // X
+    INSERT,            // I
+    DELETE,            // D
+    SKIP,              // N
+    CLIP_SOFT,         // S
+    CLIP_HARD,         // H
+    PAD,               // P
+    SEQUENCE_MATCH,    // =
+    SEQUENCE_MISMATCH  // X
 }
 
 record GACigarUnit {


### PR DESCRIPTION
It is now possible to describe the entire chimeric alignment in one GARead record. In case of a graph reference, each linear alignment could be an alignment to a segment in the graph. Note that in GACigarOperation, I am using single-character values. I believe this is easier for people who routinely work with the SAM format.

This pull request addresses #3, #8, #9, #22, #28 and #30.
