### PR TITLE
Added GAFragment type

### DIFF
--- a/src/main/resources/avro/readmethods.avdl
+++ b/src/main/resources/avro/readmethods.avdl
@@ -21,6 +21,10 @@ record GASearchReadsRequest {
   // specified, this defaults to the contig's length.
   union { null, long } end_position = null;
 
+  // In the response, each fragment contains one and only one linear alignment
+  // with a complete CIGAR.
+  union { null, boolean } separateFragment = true;
+
   // The continuation token, which is used to page through large result sets.
   // To get the next page of results, set this parameter to the value of
   // "nextPageToken" from the previous response.
@@ -29,10 +33,10 @@ record GASearchReadsRequest {
 
 // This is the response from POST /reads/search
 record GASearchReadsResponse {
-  // The list of matching Reads. The resulting Reads are sorted by position.
-  // Unmapped reads, which have no position, are returned last and are further
-  // sorted by name.
-  union { null, array<GARead> } reads = null;
+  // The list of matching fragments. The resulting fragments are sorted by
+  // the first linear alignment of the first read in each fragment. Unmapped
+  // fragments, which have no position, are returned last.
+  union { null, array<GAFragment> } fragments = null;
 
   // The continuation token, which is used to page through large result sets.
   // Provide this value in a subsequent request to return the next page of

--- a/src/main/resources/avro/reads.avdl
+++ b/src/main/resources/avro/reads.avdl
@@ -98,6 +98,7 @@ record GALinearAlignment { // a linear alignment can be represented by one CIGAR
     string contigName;
     long position; // 0-based position
     boolean reverseStrand; // the alignment is on the reverse strand of the reference sequence.
+	union { null, boolean } secondary = false; // SAM flag 0x100
     union { null, int } mappingQuality = null;
     array<GACigarUnit> cigar = []; 
     array<GAKeyValue> tags = [];
@@ -114,6 +115,10 @@ record GARead {
     // supporting the feature.
     array<GALinearAlignment> alignment = [];
 
+	// Specify whether all the linear alignments of the read are present in
+	// alignment[]. Set to null (i.e. absent) if unknown.
+	union { null, boolean } complete = null;
+
     // The list of bases that this read represents (e.g. 'CATCGA'). (SEQ)
     union { null, string } baseSequence = null;
 
@@ -129,6 +134,9 @@ record GAFragment {
     // The ID of the ReadGroup this fragment belongs to. (Every fragment must belong to exactly one ReadGroup.)
     string readGroupId;
 
+	// unique in a ReadGroup
+	union { null, string } fragmentId = null;
+
 	// The fragment is suppposed to be free of strucutral variations. For
 	// paired-end reads, this flag is reduced to the "properly paired" SAM flag
 	// (bit 0x2). It is typically set by the mapper to inform downstream tools.
@@ -139,6 +147,10 @@ record GAFragment {
 
 	// Reads sequenced from this fragment. The array order is the sequencing order.
 	array<GARead> reads;
+
+	// Specify whether all the reads in the fragment are present in reads[].
+	// Set to null (i.e. absent) if unknown. Similar to GARead::complete.
+	union { null, boolean } complete = null;
 
     // Length of the original piece of dna that produced both this read and the
     // paired read. (TLEN)


### PR DESCRIPTION
Put GARead into GAFragment. A (DNA) fragment is the template from which one or more reads are sequenced. In particular, the two ends in a read pair are sequenced from the same fragment.

I am neutral to this change. Just show what data types look like when we have GAFragment.

This pull request is related to #18.
