### PR TITLE
Alternative fragment proposal - read field reorganization

### DIFF
--- a/src/main/resources/avro/reads.avdl
+++ b/src/main/resources/avro/reads.avdl
@@ -104,11 +104,6 @@ record GALinearAlignment { // a linear alignment can be represented by one CIGAR
     array<GACigarUnit> cigar = []; 
 }
 
-record GAMateId { // The information needed to find a Read's mate
-  string contig;
-  long position;
-}
-
 record GARead {
     // Fragment information
     // These fields are the same for all Reads in a fragment.
@@ -121,8 +116,8 @@ record GARead {
     string readgroupId;
     
     // The mate ids can be used to lookup other Reads that came from the same fragment.
-    // All mates are in the same readgroup.
-    array<GAMateId> mateIds = [];
+    // All mates are in the same readgroup. This array includes the current Read's ID. 
+    array<string> mateIds = [];
     
     // Length of the original piece of DNA that produced both this read and its mates. (TLEN)
     union { null, int } templateLength = null;     
@@ -131,11 +126,9 @@ record GARead {
     // Read information
     // These fields are specific to each Read.
     
-    // The index of this Read in the mateIds array
-    // If the read is the first of a pair, the value will be 0. 
-    // If the read is the second of a pair, it would be 1.
-    union { int, null } mateIndex = null;
-
+    // The read ID.
+    string id;
+    
     // Read flags (all default to false)
     union { boolean, null } properPair = false;
     union { boolean, null } readMapped = false;


### PR DESCRIPTION
This is an alternative proposal to #47 and #38 which takes smaller baby steps towards cleaning up mates/fragments.

This proposal is trying to be implementor-friendly, by keeping the fields on a read aligned with what's available in a BAM read (thus the removal of the mate cigar and mappingQuality fields) and removing the concept of read IDs (in favor of the contig/position lookup that is in common practice right now, closing #18) while still supporting more than 1 mate.

I'm sure we can further cleanup the read flag booleans and other comments, but I wanted to see what people thought about this overall direction.
