### PR TITLE
Replaced GADataset with nested GAGroupCollection

### DIFF
--- a/src/main/resources/avro/reads.avdl
+++ b/src/main/resources/avro/reads.avdl
@@ -33,7 +33,6 @@ record GAKeyValue {
 
 enum GACollectionType { // add other types (e.g. experiment/library/sample) if necessary
     RUN, // SRA Run
-    STUDY, // SRA Study
     PROJECT // NCBI BioProject, which is recursive by itself
 }
 


### PR DESCRIPTION
GAGroupCollection is not tied to a specific type of metadata or an existing data type in SRA/ENA. It instead defines generic grouping. Depending on the collectionType field, a Collection object may represent a SRA run, a SRA experiment, a SRA study, a nested BioProject, or any arbitrary grouping fitting in a tree structure. It allows flexible and extensible hierarchy and opens the possibility to match the existing metadata at all levels.

In this commit, GAReadGroup and GAGroupCollection objects are organized in a tree structure, with an external node being a GAReadGroup object and an internal node being a GAGroupCollection object.

EDIT: this is a tentative proposal. I am actually fine with a world without an intermediate data type between GAReadGroup and GADataSet. Nonetheless, if we want to introduce an intermediate data type, I think recursion is a good direction.
