### PR TITLE
Enhanced .gitignore with the gitignore CLI tool

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,68 @@
 target
 *~
 #*
+
+#********** windows template**********
+
+# Windows image file caches
+Thumbs.db
+
+# Folder config file
+Desktop.ini
+
+# Recycle Bin used on file shares
+$RECYCLE.BIN/
+
+
+#********** osx template**********
+
+.DS_Store
+
+# Thumbnails
+._*
+
+# Files that might appear on external disk
+.Spotlight-V100
+.Trashes
+
+
+#********** linux template**********
+
+.*
+!.gitignore
+*~
+
+# KDE
+.directory
+
+
+#********** emacs template**********
+
+*~
+\#*\#
+/.emacs.desktop
+/.emacs.desktop.lock
+.elc
+auto-save-list
+tramp
+.\#*
+
+# Org-mode
+.org-id-locations
+*_archive
+
+
+#********** vim template**********
+
+.*.sw[a-z]
+*.un~
+Session.vim
+
+
+#********** maven template**********
+
+target/
+
+#********** Travis CI **********
+
+!.travis.yml


### PR DESCRIPTION
- Added OS support for OS X, Windows, Linux
- Added editor support for emacs and Vim
- Added Travis CI support back in for .travis.yml file (taken out by Linux template)
