### PR TITLE
Change type of baseQuality to an array of int

### DIFF
--- a/src/main/resources/avro/reads.avdl
+++ b/src/main/resources/avro/reads.avdl
@@ -26,7 +26,7 @@ record GAProgram {
   union { null, string } version = null;
 }
 
-record GAKeyValue { 
+record GAKeyValue {
     string key;
     string value = null;
 }
@@ -49,10 +49,10 @@ record GAReadGroup {
 
   // The readgroup description.
   union {null, string} description = null;
-  
+
   // The sample this readgroup's data was generated from.
   union { null, string } sample;
-  
+
   union { null, string } library = null;
   union { null, string } platformUnit = null;
   union { null, int } predictedInsertSize = null;
@@ -64,13 +64,13 @@ record GAReadGroup {
 
   // The number of reads in this readgroup.
   union {null, long} readCount = null;
-  
+
   // The programs used to generate this readgroup.
   array<GAProgram> programs = [];
 
   // The reference sequences the reads in this readgroup are aligned to.
   array<GAReferenceSequence> referenceSequences = [];
-  
+
   // Additional information
   array<GAKeyValue> tags = [];
 }
@@ -101,13 +101,13 @@ record GALinearAlignment { // a linear alignment can be represented by one CIGAR
     string contigName;
     long position;
     union { null, int } mappingQuality = null;
-    array<GACigarUnit> cigar = []; 
+    array<GACigarUnit> cigar = [];
 }
 
 record GARead {
     // The read ID
     union { null, string } id = null;
-  
+
     // The name of the read. When imported from a BAM file, this is the query
     // template name. (QNAME)
     union { null, string } name = null;
@@ -135,20 +135,21 @@ record GARead {
     // supporting the feature.
     array<GALinearAlignment> alignment = [];
 
-    // The mate alignment. 
+    // The mate alignment.
     array<GALinearAlignment> mateAlignment = [];
 
     // Length of the original piece of dna that produced both this read and the
     // paired read. (TLEN)
-    union { null, int } templateLength = null; 
+    union { null, int } templateLength = null;
 
     // The list of bases that this read represents (e.g. 'CATCGA'). (SEQ)
     union { null, string } originalBases = null;
 
-    // Represents the quality of each base in this read. Each character represents
-    // one base. To get the quality, take the ASCII value of the character and
-    // subtract 33. (QUAL)
-    union { null, string } baseQuality = null;
+    /**
+    An array of the [Phred quality score](http://en.wikipedia.org/wiki/Phred_quality_score)
+    for each base of `originalBases`
+    */
+    array<int> baseQuality = [];
 
     array<GAKeyValue> tags = [];
 }


### PR DESCRIPTION
Addresses issue #4 
- Updated type of GARead.baseQuality to be array<int>
- Updated documentation of GARead.baseQuality
- Some trailing spaces automatically deleted
