### PR TITLE
Adds a basic GASample object

### DIFF
--- a/src/main/resources/avro/common.avdl
+++ b/src/main/resources/avro/common.avdl
@@ -22,7 +22,7 @@ protocol GACommon {
   record GASample {
     // TODO: Add other fields from the metadata team
     
-    /** The IDs of readsets genereated from this sample. */
+    /** The IDs of readgroups generated from this sample. */
     array<string> readgroupIds = [];
     
     /** The IDs of callsets generated from this sample. */


### PR DESCRIPTION
This is a spin off from #49 (and @richarddurbin) which links callsets and readgroups to the sample they came from.

It's currently a shell object, and will need flushing out after the metadata team figures out what else belongs with a sample (and/or who stores samples, etc).
