### PR TITLE
readmethods.avdl style cleanups

### DIFF
--- a/src/main/resources/avro/readmethods.avdl
+++ b/src/main/resources/avro/readmethods.avdl
@@ -4,71 +4,71 @@ protocol GAReadMethods {
 import idl "reads.avdl";
 
 /******************  /reads/search  *********************/
-/* This request maps to the body of POST /reads/search. */
+/** This request maps to the body of POST /reads/search. */
 record GASearchReadsRequest {
-  /* If specified, restrict this query to reads within the given readgroups. */
+  /** If specified, restrict this query to reads within the given readgroups. */
   union { null, array<string> } readgroupIds = null;
 
-  /* The contig to query (e.g. 'X' for the X chromosome).
-     Leaving this blank returns results from all contigs, including unmapped reads.
+  /** The contig to query (e.g. 'X' for the X chromosome).
+      Leaving this blank returns results from all contigs, including unmapped reads.
    */
   union { null, string } contig = null;
 
-  /* The start position (0-based) of this query.
-     If a contig is specified, this defaults to 0.
+  /** The start position (0-based) of this query.
+      If a contig is specified, this defaults to 0.
    */
   union { null, long } startPosition = null;
 
-  /* The end position (0-based, inclusive) of this query.
-     If a contig is specified, this defaults to the contig's length.
+  /** The end position (0-based, inclusive) of this query.
+      If a contig is specified, this defaults to the contig's length.
    */
   union { null, long } endPosition = null;
 
-  /* The continuation token, which is used to page through large result sets.
-     To get the next page of results, set this parameter to the value of
-     `nextPageToken` from the previous response.
+  /** The continuation token, which is used to page through large result sets.
+      To get the next page of results, set this parameter to the value of
+      `nextPageToken` from the previous response.
    */
   union { null, string } pageToken = null;
 }
 
-/* This is the response from POST /reads/search. */
+/** This is the response from POST /reads/search. */
 record GASearchReadsResponse {
-  /* The list of matching alignment records, sorted by position.
-     Unmapped reads, which have no position, are returned last.
+  /** The list of matching alignment records, sorted by position.
+      Unmapped reads, which have no position, are returned last.
    */
   union { null, array<GAReadAlignment> } alignments = null;
 
-  /* The continuation token, which is used to page through large result sets.
-     Provide this value in a subsequent request to return the next page of results.
-     This field will be empty if there aren't any additional results.
+  /** The continuation token, which is used to page through large result sets.
+      Provide this value in a subsequent request to return the next page of results.
+      This field will be empty if there aren't any additional results.
    */
   union { null, string } nextPageToken = null;
 }
 
 /******************  /readgroupsets/search  *********************/
-/* This request maps to the body of POST /readgroupsets/search. */
+/** This request maps to the body of POST /readgroupsets/search. */
 record GASearchReadgroupSetsRequest {
-  /* The list of datasets to search. */
+  /** The list of datasets to search. */
   array<string> datasetIds = [];
 
-  /* Only return readgroup sets for which a substring of the name matches this string. */
+  /** Only return readgroup sets for which a substring of the name matches this string. */
   union { null, string } name = null;
 
-  /* The continuation token, which is used to page through large result sets.
-     To get the next page of results, set this parameter to the value of
-     `nextPageToken` from the previous response.
+  /** The continuation token, which is used to page through large result sets.
+      To get the next page of results, set this parameter to the value of
+      `nextPageToken` from the previous response.
    */
   union { null, string } pageToken = null;
 }
 
-// This is the response from POST /readgroupsets/search
+/** This is the response from POST /readgroupsets/search */
 record GASearchReadgroupSetsResponse {
-  /* The list of matching readgroup sets. */
+  /** The list of matching readgroup sets. */
   array<GAReadgroupSet> readgroupSets = [];
 
-  /* The continuation token, which is used to page through large result sets.
-     Provide this value in a subsequent request to return the next page of results.
-     This field will be empty if there aren't any additional results.
+  /** The continuation token, which is used to page through large result sets.
+      Provide this value in a subsequent request to return the next page of results.
+      This field will be empty if there aren't any additional results.
    */
   union { null, string } nextPageToken = null;
 }


### PR DESCRIPTION
This is a style cleanup only; no substantive changes intended. What I did:
- use /\* comments */ (vs. // comments)
- use camelCase (vs. underscore_separated) for field names

I've only touched readmethods.avdl so far -- let's agree on details and get this merged, and then we can make the same changes to reads.avdl.
