### PR TITLE
Fix broken link in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,23 +7,40 @@
 The [Global Alliance for Genomics and Health][ga4gh] is an international
 coalition, formed to enable the sharing of genomic and clinical data.
 
-The [Data Working Group](http://genomicsandhealth.org/our-work/working-groups/data-working-group) concentrates on data representation, storage, and analysis, including working with platform development partners and industry leaders to develop standards that will facilitate interoperability.
+The [Data Working
+Group](http://genomicsandhealth.org/our-work/working-groups/data-working-group)
+concentrates on data representation, storage, and analysis, including working
+with platform development partners and industry leaders to develop standards
+that will facilitate interoperability.
 
-Each area of genomics and health has a dedicated team working to define those standards.
+Each area of genomics and health has a dedicated team working to define those
+standards.
 
 
 ## Reads Task Team
 
-The [Reads Task Team](https://groups.google.com/forum/#!forum/dwgreadtaskteam) is focused on standards for accessing genomic read data -- collections of primary data collected from sequencing machines.
+The [Reads Task Team](https://groups.google.com/forum/#!forum/dwgreadtaskteam)
+is focused on standards for accessing genomic read data -- collections of
+primary data collected from sequencing machines.
 
 The team will deliver:
-  1. Data model. An abstract, mathematically complete and precise model of the data that is manipulated by the API. See the [Avro directory](src/main/resources/avro) for our in-progress work on defining v0.5 of the data model. 
-  2. API Specification. A human-readable document introducing and defining the API, accompanied by a formal specification. See the [documentation page](https://ga4gh.github.io/apis/reads/v0.1/) for the published v0.1 API.
-  3. Reference Implementation. Open source working code demonstrating the API, ideally which can underpin real world working implementations.
+
+  1. Data model. An abstract, mathematically complete and precise model of the
+     data that is manipulated by the API. See the [Avro
+     directory](src/main/resources/avro) for our in-progress work on defining
+     v0.5 of the data model. 
+  2. API Specification. A human-readable document introducing and defining the
+     API, accompanied by a formal specification. See the [documentation
+     page](https://ga4gh.github.io/apis/reads/v0.1/) for the published v0.1
+     API.
+  3. Reference Implementation. Open source working code demonstrating the API,
+     ideally which can underpin real world working implementations.
 
 ## Reference Variation Task Team
 
-The Reference Variation Task Team is focused on standards for storing and accessing reference genome and variant data -- the results of analysis of primary data collected from sequencing machines.
+The Reference Variation Task Team is focused on standards for storing and
+accessing reference genome and variant data -- the results of analysis of
+primary data collected from sequencing machines.
 
 ## File Formats Task Team
 


### PR DESCRIPTION
This PR changes a broken (PDF) link for the Data Working Group  to the appropriate web page on genomicsandhealth.org. I also reformatted the Markdown source so that lines are <= 80 characters so that diffs on future changes are easier to understand.
