### PR TITLE
Tentative proposal on replacing GADataset with GAProject and adding GASample

### DIFF
--- a/src/main/resources/avro/common.avdl
+++ b/src/main/resources/avro/common.avdl
@@ -19,4 +19,59 @@ protocol GACommon {
     string value = null;
   }
 
+  /**
+   A GAProject is defined by a submitter. It is typically a collection of data
+   obtained from the same type of experiment (e.g. whole-genome resequencing)
+   for the same research goal (e.g. pilot SNP discovery or discovery of de novo
+   mutations). GAProjects are disjoint. Examples: "1000g pilot2 low-coverage
+   sequencing", "1000g low-coverage sequencing" and "1000g exome sequencing"
+   are three different GAProjects.
+  */
+  record GAProject {
+
+  	/** Internal project ID. Unique in a read store instance. */
+    string id;
+
+	/** Project common names. Not necessarily unique. All the three 1000g
+	 sub-projects in the example above may have the same project names
+	 ["1000g", "1kg"]. */
+	array<string> names = [];
+
+	/** Project description */
+	union { null, string } description = null;
+
+	/** Other project attributes */
+	array<GAKeyValue> info = [];
+
+	/** Accessions in the BioProject database */
+	array<string> accessions = [];
+  }
+
+  /**
+   A GASample is a tuple (project,sample), where "sample" is the sample name
+   (typically on a @RG line in a SAM file) submitted under a "project". It
+   effectively represents the molecular material from which sequence data are
+   obtained. It is common that multiple GASamples have an identical sample
+   name. The data submitted under the same sample name will be assigned to
+   different GASample IDs, one ID for each project.
+  */
+  record GASample {
+
+  	/** Internal ExperimentSample ID. Unique in a read store instance. */
+  	string id;
+
+	/** The ID of GAProject under which the sample is submitted. */
+	string projectId;
+
+	/** The submitted sample name, typically on a @RG line in a SAM file.
+	 By the definition of GASample, tuple (projectId,name) is unique across a
+	 read store instance. This puts a constraint on the scope of GAProject. */
+	string name;
+
+	/** Accessions in the BioSample database. It is possible that two
+	 GASamples have the same BioSample accession and one GASample is associated
+	 with multiple BioSample accessions (there is a hierarchy in BioSample). */
+	array<string> accessions = [];
+  }
+
 }

--- a/src/main/resources/avro/reads.avdl
+++ b/src/main/resources/avro/reads.avdl
@@ -53,18 +53,13 @@ record GAProgram {
   union { null, string } version = null;
 }
 
-record GADataSet {
-    string id;
-    union { null, string } description = null;
-}
-
 record GAReadGroup {
 
   // The readgroup ID.
   string id;
 
-  // The ID of the dataset this readgroup belongs to.
-  union {null, string} datasetId = null;
+  // The ID of the project this readgroup belongs to.
+  union {null, string} projectId = null;
 
   // The readgroup name.
   union {null, string} name = null;
@@ -72,8 +67,8 @@ record GAReadGroup {
   // The readgroup description.
   union {null, string} description = null;
 
-  // The sample this readgroup's data was generated from.
-  union { null, string } sample;
+  // The GASample this readgroup's data was generated from.
+  union { null, string } sampleId = null;
 
   union { null, string } library = null;
   union { null, string } platformUnit = null;
@@ -101,8 +96,8 @@ record GAReadgroupSet {
   // The readgroup set ID.
   string id;
 
-  // The ID of the dataset this readgroup set belongs to.
-  union {null, string} datasetId = null;
+  // The ID of the project this readgroup set belongs to.
+  union {null, string} projectId = null;
 
   // The readgroup set name.
   union {null, string} name = null;

--- a/src/main/resources/avro/variants.avdl
+++ b/src/main/resources/avro/variants.avdl
@@ -10,9 +10,6 @@ record GAVariantSet {
   // The variant set ID.
   string id;
   
-  // The ID of the dataset this variant set belongs to.
-  string datasetId;
-  
   // TODO: Add reference sequence ID information once resolved.
   
   // IDs of the call samples that belong to this variant set.
@@ -36,7 +33,11 @@ record GACallSample {
   // The callsample name.
   union { null, string } name = null;
   
-  // TODO: Add Sample ID once there is a GASample object (or equivalent)
+  // The GASample IDs from which the calls for this sample are made. It is
+  // possible that one GACallSample is associated with multiple GASamples. This
+  // may happen when we merge sequence data of the same individual across
+  // multiple projects.
+  array<string> sampleIds = [];
 
   // The IDs of the variant sets this callsample has calls in.
   array<string> variantSetIds = [];


### PR DESCRIPTION
The objects are simple but the interpretation and the scope are complex. Please see the in-code comments for detailed explanation. I have not added methods or changed every related field. Let's see how far we go. If this PR gets rejected quickly, I will save some time.

In the following, I am giving some background.

Firstly, a sample "NA12878" means different things in different projects. In 1000g pilot1, it represents high-coverage WGS data. In 1000g exome sequencing sub-project, it represents targeted sequencing data. In ENCODE long RNA-seq project, it represents RNA-seq data. This means we have to "subdivide" a sample name NA12878. In the examples above, the combination of (NA12878,project) is almost always an unambiguous and meaningful unit. GASample is defined based on this observation. For this definition to work, I also have to clarify GAProject/GADataset, in particular requiring them to be disjoint.

Secondly, about the BioSample database. From my limited (if not mistaken) queries to the database, NCBI and EBI differ. They both introduce a hierarchy and share the leaf nodes, but the internal nodes are not shared. In NCBI, a BioSample object is recursive by itself. EBI on the other hand introduces a new BioSampleGroup object. The internal nodes are not exchangeable. Anyway, the shared leaf nodes are very specific. If we search NA12878 in EBI, we will get 58 BioSamples and 21 BioSampleGroups (I don't know who defines Groups). In NCBI, 275 BioSamples, some of which are internal nodes. Although both the proposed GASample and the leaf nodes of BioSample are specific, they still have different scopes. A BioSample may appear in multiple SRA studies/BioProjects (e.g. SAMN00001544), but I am treating such a BioSample as multiple GASamples. As a result, BioSample and GASample have a many-to-many relationship.

Thirdly, about sample name. Due to the complication in my first point, the BioSample database is reluctant to use a sample name NA12878. When we search for NA12878, it appears in all kinds of attributes such as "hapmap", "cell line" and even in full text. I _guess_ this is partly why NCBI and EBI give very different results on the same query although they are supposed to share most of the primary data. I think users and data producers would more like to call their samples as NA12878, _within their projects_. In addition, I am sure many labs will submit a BAM with a sample name "tumor". This is fine as they are still distinguishable by project.

---

Personally, I'd like to add a GAProject::projectType, which may take a value WGS, TARGET, RNASEQ, CHIPSEQ, etc. I think this will greatly help me to pinpoint the right data. I have deferred it for now.

In addition, as we are talking about permissions in another thread, I also have an opinion on this topic. I think we should attach a GAPermission object to both GAProject and GASample with the GASample permission overriding GAProject when both are present.

The relationship between GAProject and the existing objects. Each GAProject is equivalent to a google dataset. Each SRA/ENA study can be considered a GAProject.
