### PR TITLE
Remove callSampleNames from SearchVariants

### DIFF
--- a/src/main/resources/avro/variantmethods.avdl
+++ b/src/main/resources/avro/variantmethods.avdl
@@ -11,14 +11,8 @@ record SearchVariantsRequest {
   // Only return variants which have exactly this name.
   union { null, string } variantName = null;
 
-  // Only return variant calls which belong to callsamples which have exactly
-  // these names. Leaving this blank returns all variant calls.
-  // At most one of callSampleNames or callSampleIds should be provided.
-  array<string> callSampleNames = [];
-
   // Only return variant calls which belong to callsamples with these ids.
   // Leaving this blank returns all variant calls.
-  // At most one of callSampleNames or callSampleIds should be provided.
   array<string> callSampleIds = [];
 
   // Required. Only return variants on this reference sequence.


### PR DESCRIPTION
I mistakenly added this field in my initial pull request.

Users can search for callSamples by name already, and once they do so they can take the resulting IDs and use the callSampleIds field, so there is no need for this extra search filter.
