### PR TITLE
Add comments for the 2 search methods

### DIFF
--- a/src/main/resources/avro/readmethods.avdl
+++ b/src/main/resources/avro/readmethods.avdl
@@ -84,8 +84,8 @@ record GASearchReadGroupSetsResponse {
 /** 
   Gets a list of `GAReadGroupSets` matching the search criteria.
   
-  POST /readgroupsets/search takes a `GASearchReadGroupSetsResponse` as its 
-  body and returns a `GASearchReadGroupSetsRequest`. 
+  POST /readgroupsets/search takes a `GASearchReadGroupSetsRequest` as its 
+  body and returns a `GASearchReadGroupSetsResponse`. 
 */
 GASearchReadGroupSetsResponse searchReadGroupSets(GASearchReadGroupSetsRequest request) throws GAException;
 }


### PR DESCRIPTION
And puts the methods in a format the doc generation understands.
