### PR TITLE
Updating code format rules for documentation comments.

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -63,8 +63,10 @@ The current code conventions for the source files are as follows:
      * Documentation comments, which are intended to be processed by avrodoc and displayed in the user-facing API documentation, must use the `/** ... */` style, and must not have a leading `*` on each internal line:
         
         ````
-        /** This documentation comment will be 
-        processed correctly by avrodoc. */
+        /** 
+          This documentation comment will be 
+          processed correctly by avrodoc.
+        */
         ````
 
         ````
@@ -85,5 +87,6 @@ The current code conventions for the source files are as follows:
         */
         ````
      
+     * All multi-line comments should have the comment text indented relative to the comment delimeters.
      * One-line non-documentation comments, intended for schema developers only, must use the `// ...` style.
 


### PR DESCRIPTION
Making it clear that the star-every-line style of documentation comment makes avrodoc unhappy. Also putting in that we ought to keep to 80 characters per line, since I think we ought to keep to 80 characters per line.
