### PR TITLE
Adding project metadata to pom.xml

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,19 +4,48 @@
   <groupId>org.ga4gh</groupId>
   <artifactId>ga4gh-format</artifactId>
   <packaging>jar</packaging>
-  <name>GA4GH: Schemas</name>
   <version>0.1.0-SNAPSHOT</version>
+
+  <name>GA4GH: Schemas</name>
+  <description>Data models and APIs for Genomic data.</description>
+  <url>https://github.com/ga4gh/schemas</url>
+  <inceptionYear>2014</inceptionYear>
+  <organization>
+    <name>Global Alliance for Genomics and Health</name>
+    <url>http://genomicsandhealth.org</url>
+  </organization>
+  <licenses>
+    <license>
+      <name>The Apache Software License, Version 2.0</name>
+      <url>http://www.apache.org/licenses/LICENSE-2.0.txt</url>
+    </license>
+  </licenses>
+  <scm>
+    <connection>scm:git:https://github.com/ga4gh/schemas</connection>
+    <developerConnection>scm:git:https://github.com/ga4gh/schemas</developerConnection>
+    <url>https://github.com/ga4gh/schemas</url>
+  </scm>
 
   <properties>
     <avro.version>1.7.6</avro.version>
+    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    <project.build.targetEncoding>UTF-8</project.build.targetEncoding>
   </properties>
 
   <build>
+    <pluginManagement>
+      <plugins>
+        <plugin>
+          <groupId>org.apache.avro</groupId>
+          <artifactId>avro-maven-plugin</artifactId>
+          <version>${avro.version}</version>
+        </plugin>
+      </plugins>
+    </pluginManagement>
     <plugins>
       <plugin>
         <groupId>org.apache.avro</groupId>
         <artifactId>avro-maven-plugin</artifactId>
-        <version>${avro.version}</version>
         <executions>
           <execution>
             <id>schemas</id>
@@ -34,26 +63,20 @@
       </plugin>
     </plugins>
   </build>
+  <dependencyManagement>
+    <dependencies>
+      <dependency>
+        <groupId>org.apache.avro</groupId>
+        <artifactId>avro</artifactId>
+        <version>${avro.version}</version>
+      </dependency>
+    </dependencies>
+  </dependencyManagement>
   <dependencies>
     <dependency>
       <groupId>org.apache.avro</groupId>
       <artifactId>avro</artifactId>
-      <version>${avro.version}</version>
-    </dependency>
-    <dependency>
-      <groupId>org.apache.avro</groupId>
-      <artifactId>avro-maven-plugin</artifactId>
-      <version>${avro.version}</version>
-    </dependency>
-    <dependency>
-      <groupId>org.apache.avro</groupId>
-      <artifactId>avro-compiler</artifactId>
-      <version>${avro.version}</version>
-    </dependency>
-    <dependency>
-      <groupId>org.apache.avro</groupId>
-      <artifactId>avro-ipc</artifactId>
-      <version>${avro.version}</version>
+      <scope>compile</scope>
     </dependency>
   </dependencies>
 


### PR DESCRIPTION
Adding project metadata to pom.xml, including everything required for the Maven Central repository except for a `developers` section, which often requires some discussion among contributors.

See
http://central.sonatype.org/pages/requirements.html

A few other sections were added (`<pluginManagement>` and `<dependencyManagement>`) to reduce Maven warnings and make the scopes of dependencies explicit (notice that several of the dependencies originally listed are not required at any scope).
