### PR TITLE
Adding avro-ipc dependency back, is now required after pull request #80

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -70,12 +70,22 @@
         <artifactId>avro</artifactId>
         <version>${avro.version}</version>
       </dependency>
+      <dependency>
+        <groupId>org.apache.avro</groupId>
+        <artifactId>avro-ipc</artifactId>
+        <version>${avro.version}</version>
+      </dependency>
     </dependencies>
   </dependencyManagement>
   <dependencies>
     <dependency>
       <groupId>org.apache.avro</groupId>
       <artifactId>avro</artifactId>
+      <scope>compile</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.avro</groupId>
+      <artifactId>avro-ipc</artifactId>
       <scope>compile</scope>
     </dependency>
   </dependencies>


### PR DESCRIPTION
Sorry if I missed a rebase or something on my pull request #84, I'm still fairly new to git, commit @75890de62736cf9b801f5e9416c652f931617687 now requires the avro-ipc dependency.

```
$ mvn clean install
[INFO] Scanning for projects...
[INFO]                                                                         
[INFO] ------------------------------------------------------------------------
[INFO] Building GA4GH: Schemas 0.1.0-SNAPSHOT
[INFO] ------------------------------------------------------------------------
[INFO] 
[INFO] --- maven-clean-plugin:2.5:clean (default-clean) @ ga4gh-format ---
[INFO] Deleting /Users/xxx/working/schemas/target
[INFO] 
[INFO] --- avro-maven-plugin:1.7.6:schema (schemas) @ ga4gh-format ---
[INFO] 
[INFO] --- avro-maven-plugin:1.7.6:protocol (schemas) @ ga4gh-format ---
[INFO] 
[INFO] --- avro-maven-plugin:1.7.6:idl-protocol (schemas) @ ga4gh-format ---
[INFO] 
[INFO] --- maven-resources-plugin:2.6:resources (default-resources) @ ga4gh-format ---
[INFO] Using 'UTF-8' encoding to copy filtered resources.
[INFO] Copying 7 resources
[INFO] 
[INFO] --- maven-compiler-plugin:2.5.1:compile (default-compile) @ ga4gh-format ---
[INFO] Compiling 42 source files to /Users/xxx/working/schemas/target/classes
[INFO] -------------------------------------------------------------
[ERROR] COMPILATION ERROR : 
[INFO] -------------------------------------------------------------
[ERROR] /Users/xxx/working/schemas/target/generated-sources/avro/org/ga4gh/GAReadMethods.java:[30,80] error: package org.apache.avro.ipc does not exist
[ERROR] /Users/xxx/working/schemas/target/generated-sources/avro/org/ga4gh/GAReadMethods.java:[35,96] error: package org.apache.avro.ipc does not exist
[INFO] 2 errors 
```

This pull request adds it back as a compile time dependency and fixes the build problem above.
