### PR TITLE
Add an id field to read alignment

### DIFF
--- a/src/main/resources/avro/reads.avdl
+++ b/src/main/resources/avro/reads.avdl
@@ -269,8 +269,13 @@ record GALinearAlignment {
 */
 record GAReadAlignment {
   
-    /** The read alignment ID. */
-    string id;
+    /** 
+      The read alignment ID. This ID is unique within the read group this 
+      alignment belongs to. This field may not be provided by all backends.
+      Its intended use is to make caching and UI display easier for 
+      genome browsers and other light weight clients.
+    */
+    union { null, string } id;
 
     /**
       The ID of the read group this read belongs to.


### PR DESCRIPTION
This id field helps callers disambiguate between reads from different API responses. This field was in v0.1, and the 3 implementors all have it - so hopefully it should be okay to keep it around. (and it's just like all of our other object ids)
