### PR TITLE
Variant position --> [start, end)

### DIFF
--- a/src/main/resources/avro/variants.avdl
+++ b/src/main/resources/avro/variants.avdl
@@ -114,6 +114,7 @@ record GAVariant {
   long start;
 
   // The end position (exclusive), resulting in [start, end) closed-open interval.
+  // This is typically calculated by start + referenceBases.length.
   long end;
 
   // The reference bases for this variant. They start at the given


### PR DESCRIPTION
In an attempt to coalesce the variant models across several different systems, I would like to recommend using start, end instead of position.  Please accept my apologies if this has already been discussed.

| Source | Coordinate system | Interval type | Position fields | Contig names |
| --- | --- | --- | --- | --- |
| ADAM | 0-based | closed-open interval | start, end | "1" or "chr1" |
| Ensembl REST client | 1-based | closed interval | start, end | "1" |
| GEMINI | 0-based | closed-open interval | start, end | "chr1" |
| Global Alliance/GA4GH v0.5 | 0-based | ? | position | "1" or "chr1" |
| Google Genomics/GA4GH v0.1 | 1-based | NA | position | "1" or "chr1" |
| VCF file | 1-based | NA | position | "1" or "chr1" |

I will also attempt pull requests at ADAM and Google Genomics for position --> start, end.

See also
https://github.com/bigdatagenomics/bdg-formats/pull/14
https://github.com/bigdatagenomics/bdg-formats/pull/13
