### PR TITLE
Remove GA prefix from type names

### DIFF
--- a/src/main/resources/avro/common.avdl
+++ b/src/main/resources/avro/common.avdl
@@ -3,7 +3,7 @@
   This protocol defines common types used in the other GA4GH protocols. It does
   not have any methods; it is merely a library of types.
 */
-protocol GACommon {
+protocol Common {
 
   /**
     A general exception type.
@@ -19,7 +19,7 @@ protocol GACommon {
     A structure for encoding arbitrary Key-Value tuples, or tags, on other
     record types.
   */
-  record GAKeyValue {
+  record KeyValue {
     /** The key for which a value is being defined. */
     string key;
     /** The value of the key. */
@@ -34,7 +34,7 @@ protocol GACommon {
     
     TODO: Add support here for universally unique base IDs.
   */
-  record GAPosition {
+  record Position {
     /**
       The name of the reference sequence (or, more technically, the scaffold) in whatever
       reference is being used. Does not generally include a "chr" prefix, so for
@@ -59,7 +59,7 @@ protocol GACommon {
     An enum for the different types of CIGAR alignment operations that exist.
     Used wherever CIGAR alignments are used.
   */
-  enum GACigarOperation {
+  enum CigarOperation {
     ALIGNMENT_MATCH,   // M
     INSERT,            // I
     DELETE,            // D
@@ -74,9 +74,9 @@ protocol GACommon {
   /**
     A structure for an instance of a CIGAR operation.
   */
-  record GACigarUnit {
+  record CigarUnit {
     /** The operation type */
-    GACigarOperation operation;
+    CigarOperation operation;
     /** The number of bases that the operation runs for */
     long operationLength;
 

--- a/src/main/resources/avro/readmethods.avdl
+++ b/src/main/resources/avro/readmethods.avdl
@@ -1,11 +1,11 @@
 @namespace("org.ga4gh")
-protocol GAReadMethods {
+protocol ReadMethods {
 
 import idl "reads.avdl";
 
 /******************  /reads/search  *********************/
 /** This request maps to the body of POST /reads/search. */
-record GASearchReadsRequest {
+record SearchReadsRequest {
   /** If specified, restrict this query to reads within the given readgroups. */
   union { null, array<string> } readGroupIds = null;
 
@@ -51,11 +51,11 @@ record GASearchReadsRequest {
 }
 
 /** This is the response from POST /reads/search. */
-record GASearchReadsResponse {
+record SearchReadsResponse {
   /** The list of matching alignment records, sorted by position.
       Unmapped reads, which have no position, are returned last.
    */
-  array<GAReadAlignment> alignments = [];
+  array<ReadAlignment> alignments = [];
 
   /** The continuation token, which is used to page through large result sets.
       Provide this value in a subsequent request to return the next page of results.
@@ -65,16 +65,16 @@ record GASearchReadsResponse {
 }
 
 /**
-  Gets a list of `GAReadAlignments` matching the search criteria.
+  Gets a list of `ReadAlignments` matching the search criteria.
   
-  POST /reads/search takes a `GASearchReadsRequest` as its body and 
-  returns a `GASearchReadsResponse`. 
+  POST /reads/search takes a `SearchReadsRequest` as its body and 
+  returns a `SearchReadsResponse`. 
 */
-GASearchReadsResponse searchReads(GASearchReadsRequest request) throws GAException;
+SearchReadsResponse searchReads(SearchReadsRequest request) throws GAException;
 
 /******************  /readgroupsets/search  *********************/
 /** This request maps to the body of POST /readgroupsets/search. */
-record GASearchReadGroupSetsRequest {
+record SearchReadGroupSetsRequest {
   /** The list of datasets to search. */
   array<string> datasetIds = [];
 
@@ -89,9 +89,9 @@ record GASearchReadGroupSetsRequest {
 }
 
 /** This is the response from POST /readgroupsets/search */
-record GASearchReadGroupSetsResponse {
+record SearchReadGroupSetsResponse {
   /** The list of matching read group sets. */
-  array<GAReadGroupSet> readGroupSets = [];
+  array<ReadGroupSet> readGroupSets = [];
 
   /** The continuation token, which is used to page through large result sets.
       Provide this value in a subsequent request to return the next page of results.
@@ -101,16 +101,16 @@ record GASearchReadGroupSetsResponse {
 }
 
 /** 
-  Gets a list of `GAReadGroupSets` matching the search criteria.
+  Gets a list of `ReadGroupSets` matching the search criteria.
   
-  POST /readgroupsets/search takes a `GASearchReadGroupSetsRequest` as its 
-  body and returns a `GASearchReadGroupSetsResponse`. 
+  POST /readgroupsets/search takes a `SearchReadGroupSetsRequest` as its 
+  body and returns a `SearchReadGroupSetsResponse`. 
 */
-GASearchReadGroupSetsResponse searchReadGroupSets(GASearchReadGroupSetsRequest request) throws GAException;
+SearchReadGroupSetsResponse searchReadGroupSets(SearchReadGroupSetsRequest request) throws GAException;
 
 /****************  /referenceSequenceSets/search  *******************/
 /** This request maps to the body of POST /referenceSequenceSets/search. */
-record GASearchReferenceSequenceSetsRequest {
+record SearchReferenceSequenceSetsRequest {
   /** If present return the record for this id.  This is the normal use of this method. */
   union { null, string } id = null;
   
@@ -137,9 +137,9 @@ record GASearchReferenceSequenceSetsRequest {
 }
 
 /** This is the response from POST /referenceSequenceSets/search. */
-record GASearchReferenceSequenceSetsResponse {
+record SearchReferenceSequenceSetsResponse {
   /** The list of matching referenceSequenceSets. */
-  array<GAReferenceSequenceSet> referenceSequenceSets = [];
+  array<ReferenceSequenceSet> referenceSequenceSets = [];
 
   /**
     The continuation token, which is used to page through large result sets.
@@ -150,16 +150,16 @@ record GASearchReferenceSequenceSetsResponse {
 }
 
 /**
-  Gets a list of `GAReadReferenceSequenceSets` matching the search criteria.
+  Gets a list of `ReadReferenceSequenceSets` matching the search criteria.
   
-  POST /referenceSequenceSets/search takes a `GASearchReferenceSequenceSetsRequest` as its body and 
-  returns a `GASearchReferenceSequenceSetsResponse`. 
+  POST /referenceSequenceSets/search takes a `SearchReferenceSequenceSetsRequest` as its body and 
+  returns a `SearchReferenceSequenceSetsResponse`. 
 */
-GASearchReferenceSequenceSetsResponse searchReferenceSequenceSets(GASearchReferenceSequenceSetsRequest request) throws GAException;
+SearchReferenceSequenceSetsResponse searchReferenceSequenceSets(SearchReferenceSequenceSetsRequest request) throws GAException;
 
 /****************  /referenceSequences/search  *******************/
 /** This request maps to the body of POST /referenceSequences/search. */
-record GASearchReferenceSequencesRequest {
+record SearchReferenceSequencesRequest {
   /** If present return the records for these ids.  This is the normal use of this method. */
   union { null, array<string> } ids = null;
 
@@ -183,9 +183,9 @@ record GASearchReferenceSequencesRequest {
 }
 
 /** This is the response from POST /referenceSequences/search. */
-record GASearchReferenceSequencesResponse {
+record SearchReferenceSequencesResponse {
   /** The list of matching referenceSequences. */
-  array<GAReferenceSequence> referenceSequences = [];
+  array<ReferenceSequence> referenceSequences = [];
 
   /**
     The continuation token, which is used to page through large result sets.
@@ -196,10 +196,10 @@ record GASearchReferenceSequencesResponse {
 }
 
 /**
-  Gets a list of `GAReadReferenceSequences` matching the search criteria.
+  Gets a list of `ReadReferenceSequences` matching the search criteria.
   
-  POST /referenceSequences/search takes a `GASearchReferenceSequencesRequest` as its body and 
-  returns a `GASearchReferenceSequencesResponse`. 
+  POST /referenceSequences/search takes a `SearchReferenceSequencesRequest` as its body and 
+  returns a `SearchReferenceSequencesResponse`. 
 */
-GASearchReferenceSequencesResponse searchReferenceSequences(GASearchReferenceSequencesRequest request) throws GAException;
+SearchReferenceSequencesResponse searchReferenceSequences(SearchReferenceSequencesRequest request) throws GAException;
 }

--- a/src/main/resources/avro/reads.avdl
+++ b/src/main/resources/avro/reads.avdl
@@ -1,15 +1,15 @@
 @namespace("org.ga4gh")
-protocol GAReads {
+protocol Reads {
 
 /*
  * This file defines the objects used to represent a hierarchy of reads and alignments:
- *    GAReadGroupSet >--< GAReadGroup --< fragment --< read --< alignment --< linear alignment
+ *    ReadGroupSet >--< ReadGroup --< fragment --< read --< alignment --< linear alignment
  *
- * A GAReadGroupSet is a logical collection of GAReadGroup's.
- * A GAReadGroup is all the data that’s processed the same way by the sequencer.
- *    There are typically 1-10 GAReadGroup's in a GAReadGroupSet.
+ * A ReadGroupSet is a logical collection of ReadGroup's.
+ * A ReadGroup is all the data that’s processed the same way by the sequencer.
+ *    There are typically 1-10 ReadGroup's in a ReadGroupSet.
  * A *fragment* is a single stretch of a DNA molecule.
- *    There are typically millions of fragments in a GAReadGroup.
+ *    There are typically millions of fragments in a ReadGroup.
  *    A fragment has a name (QNAME in BAM spec), a length (TLEN in BAM spec), and an array of reads.
  * A *read* is a contiguous sequence of bases.
  *    There are typically only one or two reads in a fragment. If there are two reads, they’re known as a mate pair.
@@ -17,18 +17,18 @@ protocol GAReads {
  * An *alignment* is the way alignment software maps a read to a reference.
  *    There’s one primary alignment, and can be one or more secondary alignments.
  *    Secondary alignments represent alternate possible mappings -- they are rarely reported by aligners.
- * A *linear alignment* maps a string of bases to a reference using a single CIGAR string.
+ * A *linear alignment* maps a string of bases to a reference using a single CIR string.
  *    There’s one representative alignment, and can be one or more supplementary alignments.
  *    Supplementary alignments represent chimeric reads -- they are rare.
  *
- * A GAReadAlignment object is a flattened representation of the bottom layers of this hierarchy.
+ * A ReadAlignment object is a flattened representation of the bottom layers of this hierarchy.
  *    There's exactly one such object per *linear alignment*.
  *    The object contains alignment info, plus fragment and read info for easy access.
  */
 
 import idl "common.avdl";
 
-record GAReferenceSequence {
+record ReferenceSequence {
   /** Unique within the repository. */
   string id;
 
@@ -70,7 +70,7 @@ record GAReferenceSequence {
   union { null, int } ncbiTaxonId = null;
 }
 
-record GAReferenceSequenceSet {
+record ReferenceSequenceSet {
   /** Unique in the repository. */
   string id;
 
@@ -91,7 +91,7 @@ record GAReferenceSequenceSet {
 
   /**
     ID from http://www.ncbi.nlm.nih.gov/taxonomy (e.g. 9606->human) 
-    `ncbiTaxonId` can be overridden for specific contained GAReferenceSequence records,
+    `ncbiTaxonId` can be overridden for specific contained ReferenceSequence records,
     e.g. for EBV in a human reference genome
   */
   union { null, int } ncbiTaxonId = null;
@@ -118,12 +118,12 @@ record GAReferenceSequenceSet {
   
   /** 
     A `ReferenceSequenceSet` may be derived from a source if it contains additional sequences, or some
-    of the sequences within it are derived (see the definition of *derived* in `GAReferenceSequence`).
+    of the sequences within it are derived (see the definition of *derived* in `ReferenceSequence`).
   */
   boolean isDerived = false;
 }
 
-record GAProgram {
+record Program {
   union { null, string } commandLine = null;
   union { null, string } id = null;
   union { null, string } name = null;
@@ -131,12 +131,12 @@ record GAProgram {
   union { null, string } version = null;
 }
 
-record GADataset {
+record Dataset {
     string id;
     union { null, string } description = null;
 }
 
-record GAReadGroup {
+record ReadGroup {
 
   /** The read group ID. */
   string id;
@@ -166,7 +166,7 @@ record GAReadGroup {
   union { null, long } readCount = null;
 
   /** The programs used to generate this read group. */
-  array<GAProgram> programs = [];
+  array<Program> programs = [];
 
   /**
     The reference sequence set the reads in this readgroup are aligned to. 
@@ -175,10 +175,10 @@ record GAReadGroup {
   union {null, string } referenceSequenceSetId = null;
 
   /** Additional information */
-  array<GAKeyValue> tags = [];
+  array<KeyValue> tags = [];
 }
 
-record GAReadGroupSet {
+record ReadGroupSet {
   /** The read group set ID. */
   string id;
 
@@ -189,22 +189,22 @@ record GAReadGroupSet {
   union { null, string } name = null;
 
   /** The read groups in this set. */
-  array<GAReadGroup> readGroups = [];
+  array<ReadGroup> readGroups = [];
   
   // NB: we require that all readgroups in the set are mapped to the same referenceSequenceSet.
 }
 
-/** a linear alignment can be represented by one CIGAR string */
-record GALinearAlignment {
-    GAPosition position;
+/** a linear alignment can be represented by one CIR string */
+record LinearAlignment {
+    Position position;
     union { null, int } mappingQuality = null;
-    array<GACigarUnit> cigar = [];
+    array<CigarUnit> cigar = [];
 }
 
 /** Each read alignment describes a linear alignment with additional information
  about the fragment and the read. A read alignment object is equivalent to a
  line in a SAM file. */
-record GAReadAlignment {
+record ReadAlignment {
   
     /** The ID of the read group this read belongs to. (Every read must belong to exactly one read group.) */
     string readGroupId;
@@ -239,7 +239,7 @@ record GAReadAlignment {
     // this linear alignment
 
     /** null if unmapped */
-    union { null, GALinearAlignment } alignment = null;
+    union { null, LinearAlignment } alignment = null;
 
     /** Whether this alignment is secondary. Equivalent to SAM flag 0x100.
      By convention, each read has one and only one alignment where both
@@ -261,10 +261,10 @@ record GAReadAlignment {
 
     /** The mapping of the primary alignment of the (readNumber+1)%numberReads
      read in the fragment. It replaces mate position and mate strand in SAM. */
-    union { null, GAPosition } nextMatePosition = null;
+    union { null, Position } nextMatePosition = null;
 
     /** Additional information */
-    array<GAKeyValue> tags = [];
+    array<KeyValue> tags = [];
 }
 
 }

--- a/src/main/resources/avro/referenceStructure.avdl
+++ b/src/main/resources/avro/referenceStructure.avdl
@@ -1,5 +1,5 @@
 @namespace("org.ga4gh")
-protocol GAReferenceStructureTypes {
+protocol ReferenceStructureTypes {
     // This schema describes a reference structure of the type described in:
     // http://arxiv.org/abs/1404.5010
     
@@ -55,38 +55,38 @@ protocol GAReferenceStructureTypes {
     
     // Keeps track of whether we are talking about the left (5') or right
     // (3') side of a Position.
-    enum GAFace {
+    enum Face {
         LEFT,
         RIGHT
     }
     
     // Identifies a side of a unique Position. Serves as a vertex in the
     // reference graph.
-    record GASide {
+    record Side {
         // The ID of the position we are talking about
         long coordinate;
         
         // The face of that position we are talking about (left or right).
-        GAFace face; 
+        Face face; 
     }
     
     // Represents an edge in the reference graph. Can be part of a block or
     // adjacency.
-    record GAEdge {
+    record Edge {
         // The 5' Side of the Edge.
-        GASide left;
+        Side left;
 
         // The 3' Side of the Edge.
-        GASide right;
+        Side right;
     }
     
     // Represents several Positions with sequential IDs, connected only to
     // each other.
-    record GABlock {
+    record Block {
         // The Edge in the graph that represents this Block. This edge must
         // connect two Sides with opposite Faces, and the coordinate of the left
         // Side must be smaller than that of the right Side.
-        GAEdge edge;
+        Edge edge;
         
         // The bases that this Block represents. There must be exactly as many
         // characters in this string as there are consecutive integers between
@@ -95,20 +95,20 @@ protocol GAReferenceStructureTypes {
     }
     
     // Represents an Adjacency between two sides of two Blocks.
-    record GAAdjacency {
+    record Adjacency {
         // The Edge in the graph that represents this Adjacency. This Edge must
         // connect two Sides which are themselves endpoints of Blocks.
-        GAEdge edge;
+        Edge edge;
     }
     
-    // The following portion of the schema describes a CIGAR alignment structure to 
+    // The following portion of the schema describes a CIR alignment structure to 
     // represent alignments between sequence graphs, and 
     // between linear strings and sequence graphs.
     
     // Wrapping object that gives a block a direction of traversal.
-    record GADirectedBlock {
+    record DirectedBlock {
         // Unoriented block
-        GABlock block;
+        Block block;
         
         // The orientation of the edge. 
         // If True the edge is oriented from the left-to-right sides (i.e. the left side of first position to the 
@@ -117,9 +117,9 @@ protocol GAReferenceStructureTypes {
     }
     
     // Defines a path within a sequence graph that represents a sequence.
-    record GAThread {
+    record Thread {
         // A sequence of directed blocks. 
-        array <GADirectedBlock> path = [];
+        array <DirectedBlock> path = [];
         
         // The zero-based offset of the first position in the first directed block edge of the thread.
         // For example, if startOffset = 0 the first and subsequent positions are included in the thread.
@@ -138,25 +138,25 @@ protocol GAReferenceStructureTypes {
         //the thread sequence with the same offsets is AG.
     }
 
-    // CIGAR style alignment between two threads.
-    record GAGraphToGraphAlignment {
+    // CIR style alignment between two threads.
+    record GraphToGraphAlignment {
         // The aligned thread from the first sequence graph.
-        GAThread thread1;
+        Thread thread1;
         
         // The aligned thread from the second sequence graph.
-        GAThread thread2;
+        Thread thread2;
         
         // The cigar string aligning the first thread to the second thread.
-        array<GACigarUnit> cigar = []; 
+        array<CigarUnit> cigar = []; 
     }
     
     // A linear alignment between an input string and a sequence graph,
-    // represented by a CIGAR string and a thread in the graph.
-    record GAStringToGraphAlignment { 
+    // represented by a CIR string and a thread in the graph.
+    record StringToGraphAlignment { 
         // The aligned thread from the sequence graph.
-        GAThread thread1;
+        Thread thread1;
         
         // The cigar string aligning the string to the given thread.
-        array<GACigarUnit> cigar = []; 
+        array<CigarUnit> cigar = []; 
     }
 }

--- a/src/main/resources/avro/variantmethods.avdl
+++ b/src/main/resources/avro/variantmethods.avdl
@@ -1,5 +1,5 @@
 @namespace("org.ga4gh")
-protocol GAVariantMethods {
+protocol VariantMethods {
 
 import idl "variants.avdl";
 
@@ -38,7 +38,7 @@ record SearchVariantsRequest {
 // This is the response from POST /variants/search
 record SearchVariantsResponse {
   // The list of matching Variants.
-  array<GAVariant> variants = [];
+  array<Variant> variants = [];
 
   // The continuation token, which is used to page through large result sets.
   // Provide this value in a subsequent request to return the next page of
@@ -64,7 +64,7 @@ record SearchCallSamplesRequest {
 // This is the response from POST /callsamples/search
 record SearchCallSamplesResponse {
   // The list of matching callsamples.
-  array<GACallSample> callSamples = [];
+  array<CallSample> callSamples = [];
 
   // The continuation token, which is used to page through large result sets.
   // Provide this value in a subsequent request to return the next page of

--- a/src/main/resources/avro/variants.avdl
+++ b/src/main/resources/avro/variants.avdl
@@ -1,12 +1,12 @@
 @namespace("org.ga4gh")
-protocol GAVariants {
+protocol Variants {
 
 import idl "common.avdl";
 
 // Variants and CallSamples both belong to a VariantSet.
 // VariantSets belong to a Dataset.
 // The VariantSet is equivalent to a VCF file.
-record GAVariantSet {
+record VariantSet {
   // The variant set ID.
   string id;
   
@@ -28,7 +28,7 @@ record GAVariantSet {
 
 // A CallSample is a collection of Variant Calls for a particular sample. 
 // It belongs to a VariantSet. This is equivalent to one column in VCF.
-record GACallSample {
+record CallSample {
 
   // The callsample ID.
   string id;
@@ -36,7 +36,7 @@ record GACallSample {
   // The callsample name.
   union { null, string } name = null;
   
-  // TODO: Add Sample ID once there is a GASample object (or equivalent)
+  // TODO: Add Sample ID once there is a Sample object (or equivalent)
 
   // The IDs of the variant sets this callsample has calls in.
   array<string> variantSetIds = [];
@@ -45,15 +45,15 @@ record GACallSample {
   union { null, long } created = null;
 
   // A map of additional callsample information.
-  array<GAKeyValue> info = [];
+  array<KeyValue> info = [];
 }
 
 // A Call represents the determination of genotype with respect to a particular
 // variant. It may include associated information such as quality and phasing.
 // For example, a Call might assign a probability of 0.32 to the occurrence of
 // a SNP named rs1234 in a callsample with the name NA12345.
-// TODO: Nest this object under GAVariant
-record GACall {
+// TODO: Nest this object under Variant
+record Call {
 
   // The ID of the callsample this variant call belongs to.
   // TODO: This field is under ongoing discussion and needs to be resolved
@@ -85,14 +85,14 @@ record GACall {
   array<double> genotypeLikelihood = [];
 
   // A map of additional variant call information.
-  array<GAKeyValue> info = [];
+  array<KeyValue> info = [];
 }
 
 // A Variant represents a change in DNA sequence relative to some reference.
 // For example, a Variant could represent a SNP or an insertion.
 // Variants belong to a VariantSet. 
 // This is equivalent to a row in VCF.
-record GAVariant {
+record Variant {
 
   // The variant ID.
   string id;
@@ -121,11 +121,11 @@ record GAVariant {
   array<string> alternateBases = [];
 
   // A map of additional variant information.
-  array<GAKeyValue> info = [];
+  array<KeyValue> info = [];
 
   // The variant calls for this particular variant. Each one represents the
   // determination of genotype with respect to this variant.
-  array<GACall> calls = [];
+  array<Call> calls = [];
 }
 
 }


### PR DESCRIPTION
Since all types are already namespaced (`@namespace("org.ga4gh")`) there isn't a need for a GA prefix on all type names.

Except for `GAException`, which clashes with java.lang.Exception; a fair argument against this pull request.
