### PR TITLE
Rename tags -> info to better match with variants

### DIFF
--- a/src/main/resources/avro/reads.avdl
+++ b/src/main/resources/avro/reads.avdl
@@ -175,7 +175,7 @@ record GAReadGroup {
   union {null, string } referenceSequenceSetId = null;
 
   /** Additional information */
-  array<GAKeyValue> tags = [];
+  array<GAKeyValue> info = [];
 }
 
 record GAReadGroupSet {
@@ -264,7 +264,7 @@ record GAReadAlignment {
     union { null, GAPosition } nextMatePosition = null;
 
     /** Additional information */
-    array<GAKeyValue> tags = [];
+    array<GAKeyValue> info = [];
 }
 
 }


### PR DESCRIPTION
Variants is using `info` for all of its `array<GAKeyValue>` and Reads was using `tags`. This rename makes them consistent.
