### PR TITLE
Update alignment docs

### DIFF
--- a/src/main/resources/avro/common.avdl
+++ b/src/main/resources/avro/common.avdl
@@ -56,18 +56,55 @@ protocol GACommon {
   
   /** 
     An enum for the different types of CIGAR alignment operations that exist.
-    Used wherever CIGAR alignments are used.
+    Used wherever CIGAR alignments are used. The different enumerated values
+    have the following usage:
+
+    * `ALIGNMENT_MATCH`: An alignment match indicates that a sequence can be
+      aligned to the reference without evidence of an INDEL. Unlike the
+      `SEQUENCE_MATCH` and `SEQUENCE_MISMATCH` operators, the `ALIGNMENT_MATCH`
+      operator does not indicate whether the reference and read sequences are an
+      exact match. This operator is equivalent to SAM's `M`.
+    * `INSERT`: The insert operator indicates that the read contains evidence of
+      bases being inserted into the reference. This operator is equivalent to
+      SAM's `I`.
+    * `DELETE`: The delete operator indicates that the read contains evidence of
+      bases being deleted from the reference. This operator is equivalent to
+      SAM's `D`.
+    * `SKIP`: The skip operator indicates that this read skips a long segment of
+      the reference, but the bases have not been deleted. This operator is
+      commonly used when working with RNA-seq data, where reads may skip long
+      segments of the reference between exons. This operator is equivalent to
+      SAM's 'N'.
+    * `CLIP_SOFT`: The soft clip operator indicates that bases at the start/end
+      of a read have not been considered during alignment. This may occur if the
+      majority of a read maps, except for low quality bases at the start/end of
+      a read. This operator is equivalent to SAM's 'S'. Bases that are soft clipped
+      will still be stored in the read.
+    * `CLIP_HARD`: The hard clip operator indicates that bases at the start/end of
+      a read have been omitted from this alignment. This may occur if this linear
+      alignment is part of a chimeric alignment, or if the read has been trimmed
+      (e.g., during error correction, or to trim poly-A tails for RNA-seq). This
+      operator is equivalent to SAM's 'H'.
+    * `PAD`: The pad operator indicates that there is padding in an alignment.
+      This operator is equivalent to SAM's 'P'.
+    * `SEQUENCE_MATCH`: This operator indicates that this portion of the aligned
+      sequence exactly matches the reference (e.g., all bases are equal to the
+      reference bases). This operator is equivalent to SAM's '='.
+    * `SEQUENCE_MISMATCH`: This operator indicates that this portion of the 
+      aligned sequence is an alignment match to the reference, but a sequence
+      mismatch (e.g., the bases are not equal to the reference). This can
+      indicate a SNP or a read error. This operator is equivalent to SAM's 'X'.
   */
   enum GACigarOperation {
-    ALIGNMENT_MATCH,   // M
-    INSERT,            // I
-    DELETE,            // D
-    SKIP,              // N
-    CLIP_SOFT,         // S
-    CLIP_HARD,         // H
-    PAD,               // P
-    SEQUENCE_MATCH,    // =
-    SEQUENCE_MISMATCH  // X
+    ALIGNMENT_MATCH,
+    INSERT,
+    DELETE,
+    SKIP,
+    CLIP_SOFT,
+    CLIP_HARD,
+    PAD,
+    SEQUENCE_MATCH,
+    SEQUENCE_MISMATCH
   }
 
   /**
@@ -80,8 +117,8 @@ protocol GACommon {
     long operationLength;
 
     /** 
-      `referenceSequence` is only used at mismatches (`SEQUENCE_MISTMATCH`, X)
-      and deletions (`DELETE`, D). Filling this field replaces the MD tag.
+      `referenceSequence` is only used at mismatches (`SEQUENCE_MISMATCH`)
+      and deletions (`DELETE`). Filling this field replaces the MD tag.
       If the relevant information is not available, leave this field as `null`.
     */
     union { null, string } referenceSequence = null;

--- a/src/main/resources/avro/reads.avdl
+++ b/src/main/resources/avro/reads.avdl
@@ -1,30 +1,32 @@
 @namespace("org.ga4gh")
-protocol GAReads {
 
-/*
- * This file defines the objects used to represent a hierarchy of reads and alignments:
- *    GAReadGroupSet >--< GAReadGroup --< fragment --< read --< alignment --< linear alignment
- *
+/**
+ This file defines the objects used to represent a hierarchy of reads and alignments:
+    GAReadGroupSet >--< GAReadGroup --< fragment --< read --< alignment --< linear alignment
+ 
  * A GAReadGroupSet is a logical collection of GAReadGroup's.
  * A GAReadGroup is all the data that’s processed the same way by the sequencer.
- *    There are typically 1-10 GAReadGroup's in a GAReadGroupSet.
- * A *fragment* is a single stretch of a DNA molecule.
- *    There are typically millions of fragments in a GAReadGroup.
- *    A fragment has a name (QNAME in BAM spec), a length (TLEN in BAM spec), and an array of reads.
- * A *read* is a contiguous sequence of bases.
- *    There are typically only one or two reads in a fragment. If there are two reads, they’re known as a mate pair.
- *    A read has an array of base values, an array of base qualities, and alignment information.
+   There are typically 1-10 GAReadGroup's in a GAReadGroupSet.
+ * A *fragment* is a single stretch of a DNA molecule. There are typically
+   millions of fragments in a GAReadGroup. A fragment has a name (QNAME in BAM
+   spec), a length (TLEN in BAM spec), and an array of reads.
+ * A *read* is a contiguous sequence of bases. There are typically only one or
+   two reads in a fragment. If there are two reads, they’re known as a mate pair.
+   A read has an array of base values, an array of base qualities, and alignment
+   information.
  * An *alignment* is the way alignment software maps a read to a reference.
- *    There’s one primary alignment, and can be one or more secondary alignments.
- *    Secondary alignments represent alternate possible mappings -- they are rarely reported by aligners.
- * A *linear alignment* maps a string of bases to a reference using a single CIGAR string.
- *    There’s one representative alignment, and can be one or more supplementary alignments.
- *    Supplementary alignments represent chimeric reads -- they are rare.
- *
- * A GAReadAlignment object is a flattened representation of the bottom layers of this hierarchy.
- *    There's exactly one such object per *linear alignment*.
- *    The object contains alignment info, plus fragment and read info for easy access.
+   There’s one primary alignment, and can be one or more secondary or
+   supplimentary alignments.  Secondary alignments represent alternate possible
+   mappings. Supplimentary alignments represent linear alignments that are subsets
+   of a chimeric alignment.
+ * A *linear alignment* maps a string of bases to a reference using a single
+   CIGAR string. There’s one representative alignment, and can be one or more
+   supplementary alignments. Supplementary alignments represent chimeric reads.
+ * A GAReadAlignment object is a flattened representation of the bottom layers
+   of this hierarchy. There's exactly one such object per *linear alignment*.
+   The object contains alignment info, plus fragment and read info for easy access.
  */
+protocol GAReads {
 
 import idl "common.avdl";
 
@@ -74,8 +76,8 @@ record GAReferenceSequence {
   boolean isDerived = false;
 
   /**
-    The `sourceDivergence` is the fraction of bases that do not match the 
-    reference this record was derived from when aligned without indels.
+    The `sourceDivergence` is the fraction of non-indel bases that do not match the 
+    reference this record was derived from.
   */
   union { null, float } sourceDivergence = null;
 
@@ -256,7 +258,7 @@ record GALinearAlignment {
     union { null, int } mappingQuality = null;
 
     /**
-      Represents the local alignment (alignment matches, indels, etc) 
+      Represents the local alignment of this sequence (alignment matches, indels, etc) 
       versus the reference. 
     */
     array<GACigarUnit> cigar = [];
@@ -309,38 +311,50 @@ record GAReadAlignment {
     /** SAM flag 0x200 */
     union { null, boolean } failedVendorQualityChecks = false;
 
-    // this linear alignment
-
-    /** null if unmapped */
+    /**
+      The linear alignment for this alignment record. This field will be
+      null if the read is unmapped.
+    */
     union { null, GALinearAlignment } alignment = null;
 
     /**
       Whether this alignment is secondary. Equivalent to SAM flag 0x100.
-      By convention, each read has one and only one alignment where both
-      secondaryAlignment and supplementaryAlignment are false. In that case,
-      the full read sequence and quality should be present.
+      A secondary alignment represents an alternative to the primary alignment
+      for this read. Aligners may return secondary alignments if a read can map
+      ambiguously to multiple coordinates in the genome.
     */
     union { null, boolean } secondaryAlignment = false;
     
     /**
       Whether this alignment is supplementary. Equivalent to SAM flag 0x800.
-      By convention, each read has one and only one alignment where both
-      secondaryAlignment and supplementaryAlignment are false. In that case,
-      the full read sequence and quality should be present.
+      Supplementary alignments are used in the representation of a chimeric
+      alignment. In a chimeric alignment, a read is split into multiple
+      linear alignments that map to different reference contigs. The first
+      linear alignment in the read will be designated as the primary alignment;
+      the remaining linear alignments will be designated as supplementary alignments.
+      These alignments may have different mapping quality scores.
+      
+      In each linear alignment in a chimeric alignment, the read will be hard clipped.
+      The `alignedSequence` and `alignedQuality` fields in the alignment record will
+      only represent the bases for its respective linear alignment.
     */
     union { null, boolean } supplementaryAlignment = false;
 
     /**
-      The bases of the read sequence contained in this alignment record. In a
-      supplementary or secondary alignment, `alignedSequence` and `alignedQuality`
-      may be shorter than the read sequence and quality, or even absent.
+      The bases of the read sequence contained in this alignment record.
+      `alignedSequence` and `alignedQuality` may be shorter than the full read sequence
+      and quality. This will occur if the alignment is part of a chimeric alignment,
+      or if the read was trimmed. When this occurs, the CIGAR for this read will
+      begin/end with a hard clip operator that will indicate the length of the excised sequence.
     */
     union { null, string } alignedSequence = null;
 
     /**
-      The quality of the read sequence contained in this alignment record. In a
-      supplementary or secondary alignment, `alignedSequence` and `alignedQuality`
-      may be shorter than the read sequence and quality, or even absent.
+      The quality of the read sequence contained in this alignment record.
+      `alignedSequence` and `alignedQuality` may be shorter than the full read sequence
+      and quality. This will occur if the alignment is part of a chimeric alignment,
+      or if the read was trimmed. When this occurs, the CIGAR for this read will
+      begin/end with a hard clip operator that will indicate the length of the excised sequence.
     */
     array<int> alignedQuality = [];
 


### PR DESCRIPTION
This is my follow on to #95; it'll need to be rebased after #95 merges before it can be merged in.

This provides more explicit definitions for the supplementary/secondary alignment flags, the cigar operators, and some of the alignment specific fields.
