### PR TITLE
Remove readCount field

### DIFF
--- a/src/main/resources/avro/reads.avdl
+++ b/src/main/resources/avro/reads.avdl
@@ -230,9 +230,6 @@ record GAReadGroup {
   */
   union { null, long } updated = null;
 
-  /** The number of reads in this read group. */
-  union { null, long } readCount = null;
-
   /** The programs used to generate this read group. */
   array<GAProgram> programs = [];
 


### PR DESCRIPTION
We haven't found this field to be too useful - and it will be non-trivial to implement, so I'm proposing removing it for v0.5
