### PR TITLE
comment cleanup for loose ends from #100

### DIFF
--- a/src/main/resources/avro/reads.avdl
+++ b/src/main/resources/avro/reads.avdl
@@ -337,6 +337,9 @@ record GAReadAlignment {
       A secondary alignment represents an alternative to the primary alignment
       for this read. Aligners may return secondary alignments if a read can map
       ambiguously to multiple coordinates in the genome.
+      
+      By convention, each read has one and only one alignment where both
+      secondaryAlignment and supplementaryAlignment are false. 
     */
     union { null, boolean } secondaryAlignment = false;
     


### PR DESCRIPTION
@fnothaft, please take a look -- I think these were the only loose ends left.

(As discussed in that previous thread, I'm not an expert on the primary/secondary and representative/supplementary terminology, but I believe this PR matches current usage.)
