### PR TITLE
Nest several metadata fields under GAExperiment

### DIFF
--- a/src/main/resources/avro/reads.avdl
+++ b/src/main/resources/avro/reads.avdl
@@ -175,6 +175,23 @@ record GADataset {
   union { null, string } description = null;
 }
 
+record GAExperiment {
+  /** The library used as part of this experiment. */
+  union { null, string } libraryId = null;
+
+  /** The platform unit used as part of this experiment. */
+  union { null, string } platformUnit = null;
+
+  /** The sequencing center used as part of this experiment. */
+  union { null, string } sequencingCenter;
+
+  /** 
+    The instrument model used as part of this experiment. 
+    This maps to sequencing technology in BAM.
+  */
+  union { null, string } instrumentModel;
+}
+
 record GAReadGroup {
 
   /** The read group ID. */
@@ -192,23 +209,11 @@ record GAReadGroup {
   /** The sample this read group's data was generated from. */
   union { null, string } sampleId;
 
-  /** The library used to generate this read group. */
-  union { null, string } libraryId = null;
-
-  /** The platform unit used to generate this read group. */
-  union { null, string } platformUnit = null;
+  /** The experiment used to generate this read group. */
+  union { null, GAExperiment } experiment;
 
   /** The predicted insert size of this read group. */
   union { null, int } predictedInsertSize = null;
-
-  /** The sequencing center used to generate this read group. */
-  union { null, string } sequencingCenter;
-
-  /** 
-    The instrument model used to generate this read group. 
-    This maps to sequencing technology in BAM.
-  */
-  union { null, string } instrumentModel;
 
   /** 
     The time at which this read group was created in milliseconds from the epoch. 


### PR DESCRIPTION
The last metadata PR was a bit wrong - the fields were renamed correctly, but they also need to be nested under a GAExperiment object. 

Eventually the metadata team will add more fields to GAExperiment, but this should get us close enough for v0.5
