### PR TITLE
Fixes avrodoc code blocks

### DIFF
--- a/src/main/resources/avro/common.avdl
+++ b/src/main/resources/avro/common.avdl
@@ -59,38 +59,38 @@ protocol GACommon {
     Used wherever CIGAR alignments are used. The different enumerated values
     have the following usage:
 
-    * `ALIGNMENT_MATCH`: An alignment match indicates that a sequence can be
+   * `ALIGNMENT_MATCH`: An alignment match indicates that a sequence can be
       aligned to the reference without evidence of an INDEL. Unlike the
       `SEQUENCE_MATCH` and `SEQUENCE_MISMATCH` operators, the `ALIGNMENT_MATCH`
       operator does not indicate whether the reference and read sequences are an
       exact match. This operator is equivalent to SAM's `M`.
-    * `INSERT`: The insert operator indicates that the read contains evidence of
+   * `INSERT`: The insert operator indicates that the read contains evidence of
       bases being inserted into the reference. This operator is equivalent to
       SAM's `I`.
-    * `DELETE`: The delete operator indicates that the read contains evidence of
+   * `DELETE`: The delete operator indicates that the read contains evidence of
       bases being deleted from the reference. This operator is equivalent to
       SAM's `D`.
-    * `SKIP`: The skip operator indicates that this read skips a long segment of
+   * `SKIP`: The skip operator indicates that this read skips a long segment of
       the reference, but the bases have not been deleted. This operator is
       commonly used when working with RNA-seq data, where reads may skip long
       segments of the reference between exons. This operator is equivalent to
       SAM's 'N'.
-    * `CLIP_SOFT`: The soft clip operator indicates that bases at the start/end
+   * `CLIP_SOFT`: The soft clip operator indicates that bases at the start/end
       of a read have not been considered during alignment. This may occur if the
       majority of a read maps, except for low quality bases at the start/end of
       a read. This operator is equivalent to SAM's 'S'. Bases that are soft clipped
       will still be stored in the read.
-    * `CLIP_HARD`: The hard clip operator indicates that bases at the start/end of
+   * `CLIP_HARD`: The hard clip operator indicates that bases at the start/end of
       a read have been omitted from this alignment. This may occur if this linear
       alignment is part of a chimeric alignment, or if the read has been trimmed
       (e.g., during error correction, or to trim poly-A tails for RNA-seq). This
       operator is equivalent to SAM's 'H'.
-    * `PAD`: The pad operator indicates that there is padding in an alignment.
+   * `PAD`: The pad operator indicates that there is padding in an alignment.
       This operator is equivalent to SAM's 'P'.
-    * `SEQUENCE_MATCH`: This operator indicates that this portion of the aligned
+   * `SEQUENCE_MATCH`: This operator indicates that this portion of the aligned
       sequence exactly matches the reference (e.g., all bases are equal to the
       reference bases). This operator is equivalent to SAM's '='.
-    * `SEQUENCE_MISMATCH`: This operator indicates that this portion of the 
+   * `SEQUENCE_MISMATCH`: This operator indicates that this portion of the 
       aligned sequence is an alignment match to the reference, but a sequence
       mismatch (e.g., the bases are not equal to the reference). This can
       indicate a SNP or a read error. This operator is equivalent to SAM's 'X'.

--- a/src/main/resources/avro/reads.avdl
+++ b/src/main/resources/avro/reads.avdl
@@ -346,8 +346,8 @@ record GAReadAlignment {
       for this read. Aligners may return secondary alignments if a read can map
       ambiguously to multiple coordinates in the genome.
 
-      By convention, each read has one and only one alignment where both
-      secondaryAlignment and supplementaryAlignment are false.
+   By convention, each read has one and only one alignment where both
+   secondaryAlignment and supplementaryAlignment are false.
     */
     union { null, boolean } secondaryAlignment = false;
 
@@ -360,9 +360,9 @@ record GAReadAlignment {
       the remaining linear alignments will be designated as supplementary alignments.
       These alignments may have different mapping quality scores.
 
-      In each linear alignment in a chimeric alignment, the read will be hard clipped.
-      The `alignedSequence` and `alignedQuality` fields in the alignment record will
-      only represent the bases for its respective linear alignment.
+   In each linear alignment in a chimeric alignment, the read will be hard clipped.
+   The `alignedSequence` and `alignedQuality` fields in the alignment record will
+   only represent the bases for its respective linear alignment.
     */
     union { null, boolean } supplementaryAlignment = false;
 


### PR DESCRIPTION
This is the smallest possible change to fix the random `code` blocks that are appearing in our docs. 

Essentially, if a newline has 4 spaces in front of it, avrodoc thinks thats a markdown code block. 

Long term, I think we need to fix our style guide to indent avro records by 2 spaces only, and then shift the bodies of the /*\* */ comments over by 1 space, so that a paragraph only ever has 3 spaces in front of it. (or - someone can patch avrodoc with a better fix :)
