### PR TITLE
Add pageSize field to all search methods

### DIFF
--- a/src/main/resources/avro/readmethods.avdl
+++ b/src/main/resources/avro/readmethods.avdl
@@ -48,6 +48,12 @@ record GASearchReadsRequest {
   union { null, long } end = null;
 
   /**
+    Specifies the maximum number of results to return in a single page. 
+    If unspecified, a system default will be used.
+   */
+  union { null, int } pageSize = null;
+
+  /**
     The continuation token, which is used to page through large result sets.
     To get the next page of results, set this parameter to the value of
     `nextPageToken` from the previous response.
@@ -92,6 +98,12 @@ record GASearchReadGroupSetsRequest {
     this string.
   */
   union { null, string } name = null;
+
+  /**
+    Specifies the maximum number of results to return in a single page. 
+    If unspecified, a system default will be used.
+   */
+  union { null, int } pageSize = null;
 
   /**
     The continuation token, which is used to page through large result sets.

--- a/src/main/resources/avro/referencemethods.avdl
+++ b/src/main/resources/avro/referencemethods.avdl
@@ -32,6 +32,12 @@ record GASearchReferenceSetsRequest {
   union { null, string } assemblyId = null;
 
   /**
+    Specifies the maximum number of results to return in a single page.
+    If unspecified, a system default will be used.
+   */
+  union { null, int } pageSize = null;
+
+  /**
     The continuation token, which is used to page through large result sets.
     To get the next page of results, set this parameter to the value of
     `nextPageToken` from the previous response.
@@ -100,6 +106,12 @@ record GASearchReferencesRequest {
     Note that different versions will have different sequences.
   */
   array<string> accessions = [];
+
+  /**
+    Specifies the maximum number of results to return in a single page.
+    If unspecified, a system default will be used.
+   */
+  union { null, int } pageSize = null;
 
   /**
     The continuation token, which is used to page through large result sets.

--- a/src/main/resources/avro/variantmethods.avdl
+++ b/src/main/resources/avro/variantmethods.avdl
@@ -34,18 +34,17 @@ record GASearchVariantsRequest {
   long end;
 
   /**
+    Specifies the maximum number of results to return in a single page.
+    If unspecified, a system default will be used.
+   */
+  union { null, int } pageSize = null;
+
+  /**
     The continuation token, which is used to page through large result sets.
     To get the next page of results, set this parameter to the value of
     `nextPageToken` from the previous response.
   */
   union { null, string } pageToken = null;
-
-  /**
-    The maximum number of variants to return in each response.
-    If more variants match this request, the `pageToken` can be used to
-    fetch the next page of responses.
-   */
-  long maxResults = 10;
 }
 
 /** This is the response from `POST /variants/search` expressed as JSON. */
@@ -92,6 +91,12 @@ record GASearchCallSetsRequest {
     string.
   */
   union { null, string } name = null;
+
+  /**
+    Specifies the maximum number of results to return in a single page.
+    If unspecified, a system default will be used.
+   */
+  union { null, int } pageSize = null;
 
   /**
     The continuation token, which is used to page through large result sets.


### PR DESCRIPTION
The compliance tests would really benefit from this field being standard in all of our search methods!
