### PR TITLE
Update various Reference{,Set} semantics.

### DIFF
--- a/src/main/resources/avro/references.avdl
+++ b/src/main/resources/avro/references.avdl
@@ -2,6 +2,11 @@
 
 protocol GAReferences {
 
+/**
+  A `GAReference` is a canonical assembled contig, intended to act as a
+  reference coordinate space for other genomic annotations. A single
+  `GAReference` might represent the human chromosome 1, for instance.
+*/
 record GAReference {
   /** The reference ID. Unique within the repository. */
   string id;
@@ -25,18 +30,16 @@ record GAReference {
   string name;
 
   /**
-    The URI from which the sequence was obtained, if not given in the
-    containing `GAReferenceSet`.
+    The URI from which the sequence was obtained.
     Specifies a FASTA format file/string with one name, sequence pair.
   */
   union { null, string } sourceURI = null;
 
   /**
-    The accession from which the sequence was obtained, if not given in the
-    containing `GAReferenceSet`.
-    In INSDC (GenBank/ENA/DDBJ) with a version number. (e.g. `GCF_000001405.26`)
+    All known corresponding accession IDs in INSDC (GenBank/ENA/DDBJ) ideally
+    with a version number, e.g. `GCF_000001405.26`.
   */
-  union { null, string } sourceAccession = null;
+  array<string> sourceAccessions;
 
   /**
     A sequence X is said to be derived from source sequence Y, if X and Y
@@ -53,48 +56,36 @@ record GAReference {
   */
   union { null, float } sourceDivergence = null;
 
-  /**
-    ID from http://www.ncbi.nlm.nih.gov/taxonomy (e.g. 9606->human)
-    if not given in the containing `GAReferenceSet`.
-  */
+  /** ID from http://www.ncbi.nlm.nih.gov/taxonomy (e.g. 9606->human). */
   union { null, int } ncbiTaxonId = null;
 }
 
+/**
+  A `GAReferenceSet` is a set of `GAReference`s which typically comprise a
+  reference assembly, such as `GRCh38`. A `GAReferenceSet` defines a common
+  coordinate space for comparing reference-aligned experimental data.
+*/
 record GAReferenceSet {
   /** The reference set ID. Unique in the repository. */
   string id;
-
-  // Keep names and lengths of sequences here, as in a BAM header.
-  // Actual sequences can be retrieved from ids.
-  // This means we can process read alignments without fetching an
-  // entire genome's worth of sequences.
 
   /** The IDs of the `GAReference` objects that are part of this set. */
   array<string> referenceIds = [];
 
   /**
-    The names of the `GAReference` objects that are part of this set.
-    (e.g. '22')
-  */
-  array<string> names = [];
-
-  /**
-    The sequence lengths of the `GAReference` objects that are
-    part of this set.
-  */
-  array<long> lengths = [];
-
-  /**
-    MD5 of the concatenation of { `reference.name`, `reference.md5checksum` } for
-    all `reference` in this `GAReferenceSet`, in array ordering consistent with
-    `referenceIds`. Reference names are 0-terminated for this computation.
+    Order-independent MD5 checksum which identifies this `GAReferenceSet`. The
+    checksum is computed by sorting all `reference.md5checksum` (for all
+    `reference` in this set) in ascending lexicographic order, concatenating,
+    and taking the MD5 of that value.
   */
   string md5checksum;
 
   /**
-    ID from http://www.ncbi.nlm.nih.gov/taxonomy (e.g. 9606->human)
-    Can be overridden by the `ncbiTaxonId` field in a specific `GAReference`.
-    (e.g. for EBV in a human reference genome)
+    ID from http://www.ncbi.nlm.nih.gov/taxonomy (e.g. 9606->human) indicating
+    the species which this assembly is intended to model. Note that contained
+    `GAReference`s may specify a different `ncbiTaxonId`, as assemblies may
+    contain reference sequences which do not belong to the modeled species, e.g.
+    EBV in a human reference genome.
   */
   union { null, int } ncbiTaxonId = null;
 
@@ -106,19 +97,14 @@ record GAReferenceSet {
   /** Public id of this reference set, such as `GRCh37`. */
   union { null, string } assemblyId = null;
 
-  /**
-    Specifies a FASTA format file/string.
-    Can be overriden by the `sourceURI` field in a specific `GAReference`.
-  */
+  /** Specifies a FASTA format file/string. */
   union { null, string } sourceURI = null;
 
   /**
-   In INSDC (GenBank/ENA/DDBJ), ideally with a version number.
-   (e.g. `GCF_000001405.26`)
-   Can be overriden by the `sourceAccession` field in a specific
-   `GAReference`.
+    All known corresponding accession IDs in INSDC (GenBank/ENA/DDBJ) ideally
+    with a version number, e.g. `NC_000001.11`.
   */
-  union { null, string } sourceAccession = null;
+  array<string> sourceAccessions;
 
   /**
     A reference set may be derived from a source if it contains


### PR DESCRIPTION
- Remove the inheritance semantics from `GAReference`. See #125.
- Support multiple source accessions. See #116.
- Remove `names` and `lengths` as these were only necessitated by the heavy payload on `GAReference::sequence` (as the removed comment indicates). See #120 which removes this.
- Make `GAReferenceSet::md5checksum` order-independent and remove the dependency on `GAReference::name`. See discussion on #115.
- Add record comments for `GAReference` and `GAReferenceSet`.
