### PR TITLE
Improve consistency for reference methods

### DIFF
--- a/src/main/resources/avro/referencemethods.avdl
+++ b/src/main/resources/avro/referencemethods.avdl
@@ -11,10 +11,10 @@ import idl "references.avdl";
 */
 record GASearchReferenceSetsRequest {
   /**
-    If present, return the reference sets for which the `md5sum`
-    matches (see record definition for md5sum construction details).
+    If present, return the reference sets which match any of the given
+    `md5checksum`s. See `GAReferenceSet::md5checksum` for details.
   */
-  union { null, string } md5sum = null;
+  array<string> md5checksums = [];
 
   /**
     If present, return reference sets for which the accession
@@ -23,7 +23,7 @@ record GASearchReferenceSetsRequest {
     that main accession will be returned, whichever version.
     Note that different versions will have different sequences.
   */
-  union { null, string } accession = null;
+  array<string> accessions = [];
 
   /**
     If present, return reference sets for which the `assemblyId`
@@ -87,10 +87,10 @@ GAReferenceSet getReferenceSet(
 */
 record GASearchReferencesRequest {
   /**
-    If present, return references for which the `md5sum`
-    matches (see record definition for md5sum construction details).
+    If present, return references which match any of the given `md5checksums`.
+    See `GAReference::md5checksum` for details.
   */
-  array<string> md5sums = [];
+  array<string> md5checksums = [];
 
   /**
     If present, return references for which the accession


### PR DESCRIPTION
- `md5checksums` is consistent with `GAReference::md5checksum`.
- Support repeated md5/accession filtering in SearchReferenceSets, to be consistent with SearchReferences.
