### PR TITLE
Constrain the outgoing reference bases alphabet

### DIFF
--- a/src/main/resources/avro/referencemethods.avdl
+++ b/src/main/resources/avro/referencemethods.avdl
@@ -184,7 +184,10 @@ record GAListReferenceBasesResponse {
    */
   long offset = 0;
 
-  /** A substring of the bases that make up this reference. */
+  /**
+    A substring of the bases that make up this reference. Bases are represented
+    as IUPAC-IUB codes; this string matches the regexp `[ACGTMRWSYKVHDBN]*`.
+  */
   string sequence;
 
   /**


### PR DESCRIPTION
A repository may be lenient in the data they accept at import-time, but should be strict in what they emit at serving-time.
