### PR TITLE
Add variant sets search method

### DIFF
--- a/src/main/resources/avro/variantmethods.avdl
+++ b/src/main/resources/avro/variantmethods.avdl
@@ -3,6 +3,53 @@ protocol GAVariantMethods {
 
 import idl "variants.avdl";
 
+/******************  /variantsets/search  *********************/
+/** This request maps to the body of `POST /variantsets/search` as JSON. */
+record GASearchVariantSetsRequest {
+  /**
+    If specified, will restrict the query to variant sets within the
+    given datasets.
+  */
+  array<string> datasetIds = [];
+
+  /**
+    Specifies the maximum number of results to return in a single page. 
+    If unspecified, a system default will be used.
+  */
+  union { null, int } pageSize = null;
+
+  /**
+    The continuation token, which is used to page through large result sets.
+    To get the next page of results, set this parameter to the value of
+    `nextPageToken` from the previous response.
+  */
+  union { null, string } pageToken = null;
+}
+
+/** This is the response from `POST /variantsets/search` expressed as JSON. */
+record GASearchVariantSetsResponse {
+  /** The list of matching variant sets. */
+  array<GAVariantSet> variantSets = [];
+
+  /**
+    The continuation token, which is used to page through large result sets.
+    Provide this value in a subsequent request to return the next page of
+    results. This field will be empty if there aren't any additional results.
+  */
+  union { null, string } nextPageToken = null;
+}
+
+/**
+  Gets a list of `GAVariantSet` matching the search criteria.
+
+  `POST /variantsets/search` must accept a JSON version of
+  `GASearchVariantSetsRequest` as the post body and will return a JSON version
+  of `GASearchVariantSetsResponse`.
+*/
+GASearchVariantSetsResponse searchVariantSets(
+    /** This request maps to the body of `POST /variantsets/search` as JSON. */
+    GASearchVariantSetsRequest request) throws GAException;
+
 /******************  /variants/search  *********************/
 /** This request maps to the body of `POST /variants/search` as JSON. */
 record GASearchVariantsRequest {


### PR DESCRIPTION
This mirrors /readsets/search and allows the compliance tests to find the data it needs.
