### PR TITLE
Clarify GASearchVariantsRequest semantics.

### DIFF
--- a/src/main/resources/avro/variantmethods.avdl
+++ b/src/main/resources/avro/variantmethods.avdl
@@ -13,7 +13,7 @@ record GASearchVariantSetsRequest {
   array<string> datasetIds = [];
 
   /**
-    Specifies the maximum number of results to return in a single page. 
+    Specifies the maximum number of results to return in a single page.
     If unspecified, a system default will be used.
   */
   union { null, int } pageSize = null;
@@ -61,9 +61,10 @@ record GASearchVariantsRequest {
 
   /**
   Only return variant calls which belong to call sets with these IDs.
-  Leaving this blank returns all variant calls.
+  If an empty array, returns variants without any call objects.
+  If null, returns all variant calls.
   */
-  array<string> callSetIds = [];
+  union { null, array<string> } callSetIds = null;
 
   /** Required. Only return variants on this reference. */
   string referenceName;


### PR DESCRIPTION
This PR clarifies the semantics of the `GASearchVariantsRequest` method. By adding the union we now have two possibilities:
1. If callSetIds is null we return all `GACall` objects associated with this variant;
2. If callSetIds is non null we return only the `GACall` objects with IDs in this list. If the list is empty we return zero `GACall` objects.

The clarification is required because the semantics of allowing the empty list to correspond to all calls is confusing, and does not allow for the situation in which we are not interested in any `GACall` objects.
