### PR TITLE
Update variants.avdl

### DIFF
--- a/src/main/resources/avro/variants.avdl
+++ b/src/main/resources/avro/variants.avdl
@@ -136,8 +136,9 @@ record GACall {
 
   /**
   The genotype likelihoods for this variant call. Each array entry
-  represents how likely a specific genotype is for this call. The value
-  ordering is defined by the GL tag in the VCF spec.
+  represents how likely a specific genotype is for this call as
+  log10(P(data | genotype)), analogous to the GL tag in the VCF spec. The
+  value ordering is defined by the GL tag in the VCF spec.
   */
   array<double> genotypeLikelihood = [];
 


### PR DESCRIPTION
Standardize genotype likelihoods to log10(P(data | phenotype)), as in the VCF GL tag. Fixes #170 .
