### PR TITLE
Allow searching for references by refSetId

### DIFF
--- a/src/main/resources/avro/referencemethods.avdl
+++ b/src/main/resources/avro/referencemethods.avdl
@@ -93,6 +93,11 @@ as JSON.
 */
 record SearchReferencesRequest {
   /**
+  If present, return only references which belong to this reference set.
+  */
+  union { null, string } referenceSetId = null;
+
+  /**
   If present, return references which match any of the given `md5checksums`.
   See `Reference::md5checksum` for details.
   */


### PR DESCRIPTION
This makes it easier to get all the references that a readgroup is using. 

Now, you can go straight from `readGroup.referenceSetId` to a list of reference objects.
