### PR TITLE
Add variantSet.referenceSetId field

### DIFF
--- a/src/main/resources/avro/variants.avdl
+++ b/src/main/resources/avro/variants.avdl
@@ -48,7 +48,10 @@ record VariantSet {
   /** The ID of the dataset this variant set belongs to. */
   string datasetId;
 
-  // TODO: Add reference sequence ID information.
+  /**
+  The reference set the variants in this variant set are using.
+  */
+  string referenceSetId;
 
   /**
   The metadata associated with this variant set. This is equivalent to


### PR DESCRIPTION
Without this field, it's very hard to discover what the valid reference names are for searchVariants. 
