### PR TITLE
Update of GASex to geneticSex in metadata

### DIFF
--- a/src/main/resources/avro/wip/metadata.avdl
+++ b/src/main/resources/avro/wip/metadata.avdl
@@ -24,7 +24,7 @@ or "disease' attributes.
 * `NOT_APPLICABLE`: Used for prokaryotes, snails, etc. Not used for humans.
 */
 
-enum geneticSex {
+enum GeneticSex {
   FEMALE,
   MALE,
   OTHER,
@@ -90,7 +90,7 @@ record Individual {
   union { null, OntologyTerm } species = null;
 
   /** The genetic sex of this individual. Use `null` when unknown. */
-  union { null, geneticSex } sex = null;
+  GeneticSex sex = null;
 
   /**
   The developmental stage of this individual. Using Uberon is recommended.


### PR DESCRIPTION
This is a re-edition of the metadata.avdl change regarding the GASex definition, competing with @cassiedoll's changes in ga4gh#138 (edit: @cassiedoll closed #138 in favor of this)
It implements some of the ideas/wishes from the discussion there and adds addtl. fixes:
- type "OTHER"
- explanation of definition/use
- deletes the "NOT_AVAILABLE" type since base is NA => 'null'
- removes the "GA" prefix

However, the move to common is not implemented here & will be done later if enough agreement.
