### PR TITLE
Approved changes to Matchmaker API for v2, from Google doc

### DIFF
--- a/src/main/resources/avro/wip/matchmaker.avdl
+++ b/src/main/resources/avro/wip/matchmaker.avdl
@@ -30,6 +30,18 @@ enum ResponseType {
 }
 
 /**
+TODO: unify with the main GA4GH representation of sex, once it is committed.
+For now, we'll use the representation in [PR #185](https://github.com/ga4gh/schemas/pull/185).
+*/
+enum geneticSex {
+  FEMALE,
+  MALE,
+  OTHER,
+  MIXED_SAMPLE,
+  NOT_APPLICABLE
+}
+
+/**
 Contact information. The contact information is for transmitting match
 results only, and may not be collected and/or used for any other purposes.
 */
@@ -140,11 +152,10 @@ record Match {
   */
   union { null, Submitter } submitter = null;
 
-  /** The biological gender at birth. Accepted values are `M` and `F`, with
-  any other value treated as `unknown`.
-  TODO: update reprentation to match PR #138.
+  /**
+  The genetic sex of this individual. Use `null` when unknown.
   */
-  union { null, string } gender = null;
+  union { null, geneticSex } sex = null;
 
   /**
   An age interval


### PR DESCRIPTION
This is a collection of changes to the API that were proposed and approved in the Google doc for the draft v2 API: https://docs.google.com/document/d/1sDp_IYenhk3kdCCEEcFL_GAPVJqpB0TDPNUC9pZ4xo8

In order to be incorporated, these changes had to be approved by representatives from 3 different matchmaker groups, with no unresolved objections.

Here is a summary of those changes:
- Changed inheritance mode to use HPO terms
- Changed variant type to use Sequence Ontology
- Remove /mmapi section of the endpoints, since this API path can be negotiated as part of the <base_remote_url>
- Made “observed” field for features boolean-compatible
- Added “id” to response, to more closely match request schema
- Moved “assembly” to optional top-level field
