### PR TITLE
Renamed `genes` object to more appropriate `genomicFeatures`

### DIFF
--- a/src/main/resources/avro/wip/matchmaker.avdl
+++ b/src/main/resources/avro/wip/matchmaker.avdl
@@ -109,8 +109,8 @@ record Feature {
   union { null, string } ageOfOnset = null;
 }
 
-/* A gene or variant. */
-record Gene {
+/* A gene or genomic variant. */
+record GenomicFeature {
   /**
   Required. A <gene symbol> from the [HGNC database](http://www.genenames.org/)
   OR <ensembl gene ID> OR <entrez gene ID>
@@ -118,15 +118,15 @@ record Gene {
   string gene;
 
   /**
-  The chromosome this gene is on. 
+  The chromosome this genomic feature is on.
   TODO: Update this representation with assistance from issue #112
   */
   union { null, string } referenceName = null;
 
-  /** The start position of this gene. (0-based) */
+  /** The start position of the variant. (0-based) */
   union { null, long } start = null;
 
-  /** The end position of this gene. (0-based, exclusive) */
+  /** The end position of the variant. (0-based, exclusive) */
   union { null, long } end = null;
 
   /**
@@ -200,16 +200,16 @@ record Match {
   array<string> disorders = [];
 
   /**
-  A list of features. At least one of `features` or `genes` is required
+  A list of features. At least one of `features` or `genomicFeatures` is required
   (having both is preferred).
   */
   array<Feature> features = [];
 
   /**
-  A list of possible causes. At least one of `features` or `genes` is
+  A list of possible causes. At least one of `features` or `genomicFeatures` is
   required (having both is preferred).
   */
-  array<Gene> genes = [];
+  array<GenomicFeature> genomicFeatures = [];
 }
 
 /** The match request. */


### PR DESCRIPTION
The `genes` object is intended to represent candidate genes or variants, making it a bit of a misnomer.

A number of alternatives were discussed in the Google doc:
* `variants`
* `variantGenes`
* `genetics`
* `sequenceFeatures`
* `genomicFeatures` (most popular)

I also fixed a potentially very-confusing typo in the description of the start and end positions (which are of the variant, not the gene). This is an uncorrected relic from before the first commit and is unfortunately incorrect in the v1 version.