### PR TITLE
Variation Reference Methods

### DIFF
--- a/src/main/resources/avro/wip/variationReference.avdl
+++ b/src/main/resources/avro/wip/variationReference.avdl
@@ -1,120 +1,145 @@
 @namespace("org.ga4gh.wip")
+/**
+A sequence graph is made progressively joining new sequence pieces, which we
+call variants, into an existing graph.  This starts with a primary sequence. For
+example consider the primary sequence in GRCh38 for a chromosome.  Then variants
+can be joined into it, starting on a defined side of a defined base in the
+existing structure, containing new sequence (potentially empty if a pure
+deletion or breakpoint) and then joining back to another defined side of another
+base in the current graph.
+
+An arbitrarily complex reference graph is built this way, but we can also use
+the same construction to specify individual variants from the reference.
+
+Any base in the graph will have a unique identity defined by its variant id and
+0-based position in the variant sequence.  It is oriented in the direction of
+the variant sequence.
+
+We support a context model for uniquely identifying bases in the graph.
+Currently this is the UCSC left-right mapping proposal as proposed by Paten,
+Haussler et al. - http://arxiv.org/abs/1404.5010
+*/
 protocol VariationReference {
 
-import idl "../common.avdl" ;
+import idl "../common.avdl";
 
-/* A sequence graph is made progressively joining new sequence pieces,
-   which we call variants, into an existing graph.  This starts with a  
-   primary sequence.  For example consider the primary sequence in
-   GRCh38 for a chromosome.  Then variants can be joined into it,
-   starting on a defined side of a defined base in the existing
-   structure, containing new sequence (potentially empty if a pure
-   deletion or breakpoint) and then joining back to another defined
-   side of another base in the current graph.
-
-   An arbitrarily complex reference graph is built this way, but we
-   can also use the same construction to specify individual variants
-   from the reference.
-
-   Any base in the graph will have a unique identity defined by its
-   variant id and 0-based position in the variant sequence.  It is
-   oriented in the direction of the variant sequence.
-
-   We support a context model for uniquely identifying bases in the
-   graph.  Currently this is the UCSC left-right mapping proposal as proposed 
-   by Paten, Haussler et al. - http://arxiv.org/abs/1404.5010
+/**
+PLUS represents forwards, or the direction of increasing coordinates, while
+MINUS represents reverse-complement, or the direction of decreasing coordinates.
 */
-
 enum VariantSide {
-  PLUS, 	   // forwards, direction of increasing coordinates
-  MINUS 	   // reverse-complement, direction of decreasing coordinates
+  PLUS,
+  MINUS
 }
 
 
 record VariantJoinLocation {
-  string variantId ;	// id of the variant in which this location is based
-  int position ;	// 0-based
-  VariantSide side ;
+  string variantId; // id of the variant in which this location is based
+  int position;     // 0-based
+  VariantSide side;
 }
 
 record Variant {
-  string id ;
+  string id;
 
-  // start and end locations of how this variant fits into the existing graph
-  // start and end are {0,0,FORWARD} for a primary sequence
-  // note that the variantId for start and end may not be the same
-  VariantJoinLocation startJoin, endJoin ;  
+  /**
+  Start and end locations of how this variant fits into the existing graph.
+  start and end are {0,0,FORWARD} for a primary sequence. Note that the
+  variantId for start and end may not be the same.
+  */
+  VariantJoinLocation startJoin, endJoin;  
 
-  string sequence ; // the sequence to insert between startJoin and endJoin.
-  // We must be able to access sequence, but could allow it to be generated
-  // from a global identifier such as a versioned INSDC accession stored in info.
-  // [Propose adding additional object to define the latter in common.avdl]
 
-   // For variants that are part of a reference to which new sequences (e.g. reads) are being mapped, 
-   // a context function must be defined in referenceVariationMethods.avdl so that bases in the reads 
-   // can be mapped to bases in the reference variant.
-   
+  /**
+  The sequence to insert between startJoin and endJoin. We must be able to
+  access sequence, but could allow it to be generated from a global identifier
+  such as a versioned INSDC accession stored in info. [Propose adding additional
+  object to define the latter in common.avdl]
+  */
+  string sequence; 
 
-  // We may need to say other things about the variant, e.g. origin, dbSNP...
+  // For variants that are part of a reference to which new sequences (e.g.
+  // reads) are being mapped, a context function must be defined in
+  // referenceVariationMethods.avdl so that bases in the reads can be mapped to
+  // bases in the reference variant.
+
+  /**
+  We may need to say other things about the variant, e.g. origin, dbSNP...
+  */
   map<string> info = {};
 }
 
-/**********************************************************************/
+/*
+Next we show how to provide information about samples.  The core idea is to
+provide Calls which each contain information about an Allele in a CallSet.
+Loosely the alleles correspond to rows in a VCF and the callsets to a column,
+but there are some key differences.
 
-/* Next we show how to provide information about samples.  The core
-   idea is to provide Calls which each contain information about an
-   Allele in a CallSet.  Loosely the alleles correspond to rows in a
-   VCF and the callsets to a column, but there are some key differences.
+First, we provide information separately about alleles not sites (unary variant
+model).  We can determine from the graph whether two alleles are incompatible in
+the same haplotype and hence "allelic" in the standard usage of the term.  Note
+that this is a pairwise relation, not transitive, so we don't support sites as
+sets of alleles in the way that VCF does.  This avoids the problems when merging
+sites in VCF.  Our merge semantics are simple: only merge identical alleles.
+Identity can be checked by name when sharing a global name and definition space,
+or recursively by how the alleles are constructed from global objects when scope
+is local.
 
-   First, we provide information separately about alleles not sites
-   (unary variant model).  We can determine from the graph whether two
-   alleles are incompatible in the same haplotype and hence "allelic"
-   in the standard usage of the term.  Note that this is a pairwise
-   relation, not transitive, so we don't support sites as sets of
-   alleles in the way that VCF does.  This avoids the problems when
-   merging sites in VCF.  Our merge semantics are simple: only merge
-   identical alleles.  Identity can be checked by name when sharing a
-   global name and definition space, or recursively by how the alleles 
-   are constructed from global objects when scope is local.
-
-   Second, we represent phase information by separate haplotype
-   callSets, rather than using some sort of | or / or | notation or
-   equivalent in the calls of a genotype callSet.  So genotype
-   callSets just contain allele counts (copy number) or dosages.  This
-   is the only way to provide phase data. Because we support sparse
-   callSets, which we hope can be lightweight, each piece of partial
-   phasing (as for example supported by phase sets in VCF) will be a
-   separate haplotype CallSet on the same sample.
+Second, we represent phase information by separate haplotype callSets, rather
+than using some sort of | or / or | notation or equivalent in the calls of a
+genotype callSet.  So genotype callSets just contain allele counts (copy number)
+or dosages.  This is the only way to provide phase data. Because we support
+sparse callSets, which we hope can be lightweight, each piece of partial phasing
+(as for example supported by phase sets in VCF) will be a separate haplotype
+CallSet on the same sample.
 */
 
-/* A Segment is a basic piece of sequence from the graph out of which
-   more complex things can be made.
+/**
+A Segment is a basic piece of sequence from the graph out of which more complex
+things can be made.
 */
 record Segment {
-  string variantId ;  //references an id of a Variant
-  int start, end ;   	// start is 0-based and inclusive, end is exclusive
-  // So start <= x < end if end > start, or end < x <= start if end < start.
-  // Genomic positions are non-negative integers less than reference length.
-  // Segments spanning the join of circular genomes are represented as 
-  // two segments, one on each side of the join (position 0).
-  VariantSide side ; 
-  int length ;	// alternative to end
-  // if start == 0 and end == 0 then this is the whole Variant
-  // and otherwise we require end != start (and equivalently that length > 0)
+  /**
+  References an id of a Variant.
+  */
+  string variantId;
+  
+  /**
+  start is 0-based and inclusive, end is exclusive. So start <= x < end if end >
+  start, or end < x <= start if end < start. Genomic positions are non-negative
+  integers less than reference length. Segments spanning the join of circular
+  genomes are represented as two segments, one on each side of the join
+  (position 0). If start == 0 and end == 0 then this is the whole Variant, and
+  otherwise we require end != start.
+  */
+  int start, end;
+       
+  VariantSide side; 
+  
+  /**
+  Alternatie to end.
+  */
+  int length;
 }
 
-/* An Allele is a contigous piece of sequence that we will want to
-   say is present (in general at some copy number) or absent in a
-   sample.  Very often it will just be a variant, but it can also be a
-   segment of the reference, or of another variant, or in the general
-   case a contigous series of segments running across variant boundaries.
+/*
+An Allele is a contigous piece of sequence that we will want to say is present
+(in general at some copy number) or absent in a sample.  Very often it will just
+be a variant, but it can also be a segment of the reference, or of another
+variant, or in the general case a contigous series of segments running across
+variant boundaries.
 */
 record Allele {
-  string id ;	// if this Allele is a clean variant, then reuse variantId
+  /**
+  If this Allele is a clean variant, then reuse variantId.
+  */
+  string id;  
 
-  array<Segment> sequence ; 	// require that segments abut in order
-  // also require they are maximal, i.e. that consecutive elements of the array 
-  // can not be replaced by a single element.
+  /**
+  Require that segments abut in order. Also require they are maximal, i.e. that
+  consecutive elements of the array can not be replaced by a single element.
+  */
+  array<Segment> sequence;   
 }
 
 enum CallSetType {
@@ -123,67 +148,115 @@ enum CallSetType {
 }
 
 record CallSet {
-  //Would be good to clarify how this relates to the CallSample object in variants.avdl
+  // Would be good to clarify how this relates to the CallSample object in
+  // variants.avdl
   
-  string id ;
+  string id;
 
-  string sampleId ;  // can use the name here in absence of better sample structure
+  /**
+  Can use the name here in absence of better sample structure.
+  */
+  string sampleId; 
 
-  CallSetType callsetType; // must be one or the other
+  /**
+  A CallSet must be either a genotype or a haplotype. This field specifies
+  which.
+  */
+  CallSetType callsetType; 
 
-  // for diploid genotypes the copy number of an allele will typically be 0, 1 or 2; for haplotypes it will be 0 or 1
+  // For diploid genotypes the copy number of an allele will typically be 0, 1
+  // or 2; for haplotypes it will be 0 or 1
 
-  // We may need to say other things about the callset, e.g. derivation
+  /**
+  We may need to say other things about the callset, e.g. derivation.
+  */
   map<string> info = {};
 }
 
 record Call {
-  string callSetId ;  // references an id of CallSet
-  string alleleID ;  // references an id of Allele
+  /**
+  References an id of CallSet
+  */
+  string callSetId;
+  
+  /**
+  References an id of Allele
+  */ 
+  string alleleID;
 
   // not all of the following will be present, but at least one should be
-  union { null, int } copyNumber = null ; // 0 for not present in callSet, 1 for single copy, 2 for 2 copies etc. 
-  union { null, float } dosage = null ; // expected value of copyNumber
-  array<float> probability = [] ; // probability that copy number is k: 0..n
-  array<float> likelihood = [] ;  // likelihood of data given copy number k
-  union { null, int } readCount = null ; // number of reads supporting this allele (DP in VCF)
-  map<string> evidence = {}; // potential other evidence for the call
+  
+  /**
+  0 for not present in callSet, 1 for single copy, 2 for 2 copies etc. 
+  */
+  union { null, int } copyNumber = null; 
+  
+  /**
+  Expected value of copyNumber.
+  */
+  union { null, float } dosage = null;
+  
+  /**
+  Probability that copy number is k: 0..n
+  */ 
+  array<float> probability = [];
+  
+  /**
+  Likelihood of data given copy number k.
+  */
+  array<float> likelihood = []; 
+  
+  /**
+  Number of reads supporting this allele (DP in VCF).
+  */
+  union { null, int } readCount = null;
+  
+  /**
+  Potential other evidence for the call.
+  */
+  map<string> evidence = {};
 }
 
-/* The call values in a callset are not explicitly
-   ordered and oriented.  This reflects typically the data we have
-   about them.  In many cases we can infer order and orientation from
-   the reference graph on which the alleles are defined, for example
-   for a sequence of simple variants (SNPs, indels etc) along a
-   reference.  But in the general case with multiple copies of alleles
-   and rearrangements this is not the case.  For when we do want to
-   explicitly state the order and orientation of alleles we define a
-   VariantScaffold record.
+/* 
+The call values in a callset are not explicitly ordered and oriented. This
+reflects typically the data we have about them.  In many cases we can infer
+order and orientation from the reference graph on which the alleles are defined,
+for example for a sequence of simple variants (SNPs, indels etc) along a
+reference.  But in the general case with multiple copies of alleles and
+rearrangements this is not the case.  For when we do want to explicitly state
+the order and orientation of alleles we define a VariantScaffold record.
 */
 
 record VariantScaffold {
-  string id ;
+  string id;
 
-  array<Allele> alleles ;
-  array<boolean> isForwards ; 	// orientation of each allele
-  array<int> gapSizes = [];   //sizes of gaps between alleles, array length is 1 less than no. of alleles
+  array<Allele> alleles;
+  
+  /**
+  Orientation of each allele.
+  */
+  array<boolean> isForwards;
+  
+  /**
+  Sizes of gaps between alleles, array length is 1 less than no. of alleles.
+  */
+  array<int> gapSizes = [];   
 }
 
-/* Finally, note that while typically an Allele is short, this
-   structure also allows us to define a long allele as a literal
-   sequence path through the graph incorporating (parts of) multiple
-   variants.
+/*
+Finally, note that while typically an Allele is short, this structure also
+allows us to define a long allele as a literal sequence path through the graph
+incorporating (parts of) multiple variants.
 
-   For example, it supports defining alleles to represent ALT haplotypes
-   from GRCh38 or an LRG (clinical locus-specific reference sequence) 
-   that differs from the canonical reference.
+For example, it supports defining alleles to represent ALT haplotypes from
+GRCh38 or an LRG (clinical locus-specific reference sequence) that differs from
+the canonical reference.
 
-   Other people may want to define variants on these "Allele"
-   sequences.  It would be possible to write code to map those onto
-   the reference graph.  This could support mapping variants between
-   coordinate systems.  There has been interesting discussion about
-   this in the context of dbSNP and representation of variation on 
-   multiple references.
+Other people may want to define variants on these "Allele" sequences.  It would
+be possible to write code to map those onto the reference graph.  This could
+support mapping variants between coordinate systems.  There has been interesting
+discussion about this in the context of dbSNP and representation of variation on
+multiple references.
 */
 
 } // end of protocol

--- a/src/main/resources/avro/wip/variationReference.avdl
+++ b/src/main/resources/avro/wip/variationReference.avdl
@@ -1,4 +1,5 @@
 @namespace("org.ga4gh.wip")
+
 /**
 A sequence graph is made progressively joining new sequence pieces, which we
 call variants, into an existing graph.  This starts with a primary sequence. For
@@ -24,6 +25,60 @@ protocol VariationReference {
 import idl "../common.avdl";
 
 /**
+A `VariationReference` is a set of `Variant`s which typically comprise a
+reference assembly, such as `GRCh38`. A `VariationReference` defines a common
+graph coordinate space for comparing reference-aligned experimental data.
+*/
+record VariationReference {
+  /** The variation reference ID. Unique in the repository. */
+  string id;
+
+  // `Variant` objects record their membership in the `VariationReference`,
+  // sicne there will be a lot of them and we probably want to paginate them.
+
+  /**
+  Order-independent MD5 checksum which identifies this `VariationReference`. The
+  checksum is computed by sorting all `md5checksum`s for all `Variant`s in the
+  reference in ascending lexicographic order, concatenating, and taking the MD5
+  of that value.
+  */
+  string md5checksum;
+
+  /**
+  ID from http://www.ncbi.nlm.nih.gov/taxonomy (e.g. 9606->human) indicating
+  the species which this assembly is intended to model. Note that contained
+  `Reference`s may specify a different `ncbiTaxonId`, as assemblies may
+  contain reference sequences which do not belong to the modeled species, e.g.
+  EBV in a human reference genome.
+  */
+  union { null, int } ncbiTaxonId = null;
+
+  /** Optional free text description of this reference set. */
+  union { null, string } description = null;
+
+  // next information about the source of the sequences
+
+  /** Public id of this reference set, such as `GRCh37`. */
+  union { null, string } assemblyId = null;
+
+  /** Specifies a FASTA format file/string. */
+  union { null, string } sourceURI = null;
+
+  /**
+  All known corresponding accession IDs in INSDC (GenBank/ENA/DDBJ) ideally
+  with a version number, e.g. `NC_000001.11`.
+  */
+  array<string> sourceAccessions;
+
+  /**
+  A reference set may be derived from a source if it contains
+  additional sequences, or some of the sequences within it are derived
+  (see the definition of `isDerived` in `Reference`).
+  */
+  boolean isDerived = false;
+}
+
+/**
 PLUS represents forwards, or the direction of increasing coordinates, while
 MINUS represents reverse-complement, or the direction of decreasing coordinates.
 */
@@ -37,26 +92,83 @@ record VariantJoinLocation {
   string variantId; // id of the variant in which this location is based
   int position;     // 0-based
   VariantSide side;
+  
+  /**
+  MD5 of the `md5checksum` of the variant being joined onto, the position as a
+  decimal string, and "+" or "-" as appropriate for the side, in that order.
+  Doesn't always have to be included, really just exists for making sure that
+  the MD5 of a Variant and thus a VariationReference is well-defined.
+  */
+  union { null, string } md5checksum = null;
 }
 
+/**
+Represents a chunk of sequence (possibly joined onto other such chunks) that is
+part of a reference graph.
+*/
 record Variant {
+
+  /** The variant ID. Unique within the repository. */
   string id;
+  
+  /**
+  The ID of the `VariationReference` that this variant belongs to, if any.
+  */
+  union { null, string } variationReferenceId = null;
+  
+  /**
+  The ID of the `VariantSet` that this variant belongs to, if it does not belong
+  to a `VariationReference`.  
+  */
+  union { null, string } variantSetId = null;
+  
+  /**
+  Names for the variant, for example a RefSNP ID.
+  */
+  array<string> names = [];
 
   /**
-  Start and end locations of how this variant fits into the existing graph.
-  start and end are {0,0,FORWARD} for a primary sequence. Note that the
-  variantId for start and end may not be the same.
+  MD5 of the sequenceMd5checksum, the MD5 of the startJoin, and the MD5 of the
+  endJoin, in that order. Note that this means a variant may not join onto
+  itself, or anything that joins onto it, or this hash would not be defined.
   */
-  VariantJoinLocation startJoin, endJoin;  
-
+  string md5checksum;
 
   /**
-  The sequence to insert between startJoin and endJoin. We must be able to
-  access sequence, but could allow it to be generated from a global identifier
-  such as a versioned INSDC accession stored in info. [Propose adding additional
-  object to define the latter in common.avdl]
+  All known corresponding accession IDs in INSDC (GenBank/ENA/DDBJ) ideally
+  with a version number, e.g. `GCF_000001405.26`.
   */
-  string sequence; 
+  array<string> sourceAccessions;
+
+  /**
+  Start and end locations of how this variant fits into the existing graph. May
+  be null only for a primary sequence that is not joined onto any other. Note
+  that the variantId for start and end may not be the same.
+  */
+  union { null, VariantJoinLocation } startJoin, endJoin;  
+  
+  /**
+  The length of this variant's sequence.
+  */
+  long length;
+  
+  /**
+  The sequence to insert between startJoin and endJoin. Must be set if sourceURI
+  is null.  
+  */
+  union { null, string } sequence = null;
+  
+  /**
+  The URI from which the sequence may be obtained, as a FASTA format file with
+  one name, sequence pair. Must be set if sequence is null.
+  */
+  union { null, string } sourceURI = null;
+  
+  /**
+  MD5 of the upper-case sequence excluding all whitespace characters
+  (this is equivalent to SQ:M5 in SAM).
+  */
+  string sequenceMd5checksum;
 
   // For variants that are part of a reference to which new sequences (e.g.
   // reads) are being mapped, a context function must be defined in
@@ -71,32 +183,109 @@ record Variant {
 
 /*
 Next we show how to provide information about samples.  The core idea is to
-provide Calls which each contain information about an Allele in a CallSet.
-Loosely the alleles correspond to rows in a VCF and the callsets to a column,
-but there are some key differences.
+provide Calls which each contain information about a set of Alleles (all of
+which are called together as having a copy number) in a CallSet. Loosely the
+allele sets correspond to rows in a VCF and the callsets to a column, but there
+are some key differences.
 
-First, we provide information separately about alleles not sites (unary variant
-model).  We can determine from the graph whether two alleles are incompatible in
-the same haplotype and hence "allelic" in the standard usage of the term.  Note
-that this is a pairwise relation, not transitive, so we don't support sites as
-sets of alleles in the way that VCF does.  This avoids the problems when merging
-sites in VCF.  Our merge semantics are simple: only merge identical alleles.
-Identity can be checked by name when sharing a global name and definition space,
-or recursively by how the alleles are constructed from global objects when scope
-is local.
+First, we provide information separately about allele sets not sites (unary
+variant model).  We can determine from the graph whether two allele sets are
+incompatible in the same haplotype and hence "allelic" in the standard usage of
+the term.  Note that this is a pairwise relation, not transitive. This avoids
+the problems when merging sites in VCF.  Our merge semantics are simple: only
+merge identical allele sets. Identity can be checked by name when sharing a
+global name and definition space, or recursively by how the alleles are
+constructed from global objects when scope is local.
 
 Second, we represent phase information by separate haplotype callSets, rather
-than using some sort of | or / or | notation or equivalent in the calls of a
-genotype callSet.  So genotype callSets just contain allele counts (copy number)
-or dosages.  This is the only way to provide phase data. Because we support
-sparse callSets, which we hope can be lightweight, each piece of partial phasing
-(as for example supported by phase sets in VCF) will be a separate haplotype
-CallSet on the same sample.
+than using some sort of | or / notation or equivalent in the calls of a genotype
+callSet. So genotype callSets just contain allele counts (copy number) or
+dosages. Because we support sparse callSets, which we hope can be lightweight,
+each piece of partial haplotype phasing (as for example supported by phase sets
+in VCF) will be a separate haplotype CallSet on the same sample. Since phasing
+onto haplotypes can still be ambiguous in the case of complex duplications and
+transpositions, we also provide a notion of Scaffolds which are ordered,
+oriented, gapped lists of Alleles that are asserted to appear on the same
+molecule.
 */
 
 /**
-A Segment is a basic piece of sequence from the graph out of which more complex
-things can be made.
+This metadata represents VCF header information. Includes both the field value
+and the information about the field definition, to allow a VCF header to be
+reconstructed.
+*/
+record VariantSetMetadata {
+  /** The top-level key. */
+  string key;
+
+  /** The value field for simple metadata. */
+  string value;
+
+  /**
+  User-provided ID field, not enforced by this API.
+  Two or more pieces of structured metadata with identical
+  id and key fields are considered equivalent.
+  */
+  string id;
+
+  /** The type of data. */
+  string type;
+
+  /**
+  The number of values that can be included in a field described by this
+  metadata.
+  */
+  string number;
+
+  /** A textual description of this metadata. */
+  string description;
+
+  /** Remaining structured metadata key-value pairs. */
+  map<array<string>> info = {};
+}
+
+/**
+A `CallSet` has calls in a `VariantSet`. Some `Variant`s belong to
+`VariantSet`s, while other belong to `VariationReference`s. A `VariantSet`
+belongs to a `Dataset`. The variant set is equivalent to a VCF file.
+*/
+record VariantSet {
+  /** The variant set ID. */
+  string id;
+
+  /** The ID of the dataset this variant set belongs to. */
+  string datasetId;
+
+  /**
+  The `VariationReference` on which this `VariantSet` is defined.
+  */
+  string variationReferenceId;
+
+  /** The date this variant set was created in milliseconds from the epoch. */
+  union { null, long } created = null;
+
+  /**
+  The time at which this variant set was last updated in milliseconds from the
+  epoch.
+  */
+  union { null, long } updated = null;
+
+  // We don't list all the CallSets we have calls in because we expect there to
+  // be many more CallSets than VariantSets.
+
+  /**
+  The metadata associated with this variant set. This is equivalent to
+  the VCF header information not already presented in first class fields.
+  */
+  array<VariantSetMetadata> metadata = [];
+}
+
+/**
+A `Segment` is a substring of a `Variant`. 1 or more `Segment`s (possibly from
+different `Variant`s) can be strung together end to end to form an `Allele`.
+
+Note that a `Segment` can be 0-length, especially if it is representing the
+entirety of a 0-length `Allele`.
 */
 record Segment {
   /**
@@ -105,35 +294,41 @@ record Segment {
   string variantId;
   
   /**
-  start is 0-based and inclusive, end is exclusive. So start <= x < end if end >
-  start, or end < x <= start if end < start. Genomic positions are non-negative
-  integers less than reference length. Segments spanning the join of circular
-  genomes are represented as two segments, one on each side of the join
-  (position 0). If start == 0 and end == 0 then this is the whole Variant, and
-  otherwise we require end != start.
+  0-based start position along the `Variant`, inclusive.
   */
-  int start, end;
-       
-  VariantSide side; 
+  long start;
   
   /**
-  Alternatie to end.
+  Number of DNA bases in the `Segment`.
   */
-  int length;
+  long length;
+    
+  /**
+  Orientation in which the `Segment` appears in its `Allele`.
+  */     
+  VariantSide side; 
 }
 
 /*
 An Allele is a contigous piece of sequence that we will want to say is present
 (in general at some copy number) or absent in a sample.  Very often it will just
-be a variant, but it can also be a segment of the reference, or of another
-variant, or in the general case a contigous series of segments running across
-variant boundaries.
+be a single segment with the entirety of a `Variant`, but it is also common for
+it to be a `Segment` of a `Variant` not overlapped by another `Variant`, or in
+general any contiguous path through the sequence graph of `Variant`s.
+
+Since `Allele`s are defined on `Variant`s, they belong to `VariantSet`s.
 */
 record Allele {
   /**
-  If this Allele is a clean variant, then reuse variantId.
+  The ID of this `Allele`. If this Allele is one segment consisting of the
+  entirety of a `Variant`, this is equal to the ID of that `Variant`.
   */
-  string id;  
+  string id;
+  
+  /**
+  The `VariantSet` to which this `Allele` belongs.
+  */
+  string variantSetId;  
 
   /**
   Require that segments abut in order. Also require they are maximal, i.e. that
@@ -142,49 +337,87 @@ record Allele {
   array<Segment> sequence;   
 }
 
+/**
+Some CallSets reflect genotype calls, while others reflect linked haplotype
+calls.
+*/
 enum CallSetType {
   GENOTYPE,
   HAPLOTYPE
 }
 
+/**
+A `CallSet` is a collection of variant calls for a particular sample. It belongs
+to a `VariantSet`. A GENOTYPE-type CallSet is approximately equivalent to one
+column in VCF.
+*/
 record CallSet {
-  // Would be good to clarify how this relates to the CallSample object in
-  // variants.avdl
-  
+
+  /** The call set ID. */
   string id;
 
-  /**
-  Can use the name here in absence of better sample structure.
-  */
-  string sampleId; 
+  /** The call set name. */
+  union { null, string } name = null;
+
+  /** The sample this call set's data was generated from. */
+  union { null, string } sampleId;
 
   /**
-  A CallSet must be either a genotype or a haplotype. This field specifies
-  which.
+  A `CallSet` must be either a genotype or a haplotype. This field specifies
+  which. A HAPLOTYPE-type `CallSet` is just a bag of `Call`s on the same piece
+  of DNA; there may be more than one way to traverse the graph as a single
+  haplotype.
   */
-  CallSetType callsetType; 
-
-  // For diploid genotypes the copy number of an allele will typically be 0, 1
-  // or 2; for haplotypes it will be 0 or 1
+  CallSetType callsetType;
+  
+  // For diploid genotypes the copy number of a Variant in a Call will typically
+  // be 0, 1 or 2; for haplotypes it will be 0 or 1
 
   /**
-  We may need to say other things about the callset, e.g. derivation.
+  The IDs of the variant sets this call set has calls in. These must all belong
+  to the same Dataset; a CallSet cannot span Datasets.
   */
-  map<string> info = {};
+  array<string> variantSetIds = [];
+
+  /** The date this call set was created in milliseconds from the epoch. */
+  union { null, long } created = null;
+
+  /**
+  The time at which this call set was last updated in milliseconds from the
+  epoch.
+  */
+  union { null, long } updated = null;
+
+  /**
+  A map of additional call set information.
+  */
+  map<array<string>> info = {};
 }
 
+/**
+A Call is an instance of a Vartiant in a CallSet.
+*/
 record Call {
   /**
-  References an id of CallSet
+  References the ID of the `CallSet` that this `Call` belongs to.
   */
   string callSetId;
   
   /**
-  References an id of Allele
+  References the ID of the `VariantSet` that this `Call` gets its `Allele`s
+  from. All `Allele`s must be in the same `VariantSet`.
+  */
+  string variantSetId;
+  
+  /**
+  References the IDs of the `Allele`s that this Call reflects the presence of.
   */ 
-  string alleleID;
-
-  // not all of the following will be present, but at least one should be
+  array<string> alleleIds;
+  
+  // HAPLOTYPE-type CallSets double as phase sets, so we don't need phase sets.
+  
+  // We have various ways of specifying what the call actually is.
+  // Not all of the following will be present, but at least one should be
   
   /**
   0 for not present in callSet, 1 for single copy, 2 for 2 copies etc. 
@@ -218,45 +451,49 @@ record Call {
 }
 
 /* 
-The call values in a callset are not explicitly ordered and oriented. This
-reflects typically the data we have about them.  In many cases we can infer
-order and orientation from the reference graph on which the alleles are defined,
-for example for a sequence of simple variants (SNPs, indels etc) along a
-reference.  But in the general case with multiple copies of alleles and
-rearrangements this is not the case.  For when we do want to explicitly state
-the order and orientation of alleles we define a VariantScaffold record.
-*/
+The `Call`s in a `CallSet` are not explicitly ordered and oriented. This
+reflects typically the data we have about them. In many cases we can infer order
+and orientation from the reference graph on which the `Allele`s are defined, for
+example for a sequence of simple variants (SNPs, indels etc) along a
+reference.But in the general case with multiple copies of `Allele`s and
+rearrangements this is not the case. For when we do want to explicitly state the
+order and orientation of `Allele`s we define an `AlleleScaffold` record.
 
-record VariantScaffold {
+TODO: This is still being worked out; it is not entirely clear how this sort of
+phasing ought to interact with haplotype phasing.
+*/
+record AlleleScaffold {
+  /**
+  ID of this `AlleleScaffold`.
+  */
   string id;
 
-  array<Allele> alleles;
-  
   /**
-  Orientation of each allele.
+  ID of the `CallSet` which this `AlleleScaffold` is associated with.
   */
-  array<boolean> isForwards;
+  string callSetId;
   
   /**
-  Sizes of gaps between alleles, array length is 1 less than no. of alleles.
+  ID of the `VariantSet` which this `AlleleScaffold` is associated with.
+  */
+  string variantSetId;
+
+  /**
+  Array of `Allele` IDs in the order they appear in the scaffold.
+  */
+  array<string> alleleIds;
+  
+  /**
+  Orientation of each `Allele` (relative to the orientation in which it is
+  defined.  
+  */
+  array<VariantSide> alleleOrientations;
+  
+  /**
+  Sizes of gaps between `Allele`s, array length is 1 less than number of
+  `Allele`s.
   */
   array<int> gapSizes = [];   
 }
-
-/*
-Finally, note that while typically an Allele is short, this structure also
-allows us to define a long allele as a literal sequence path through the graph
-incorporating (parts of) multiple variants.
-
-For example, it supports defining alleles to represent ALT haplotypes from
-GRCh38 or an LRG (clinical locus-specific reference sequence) that differs from
-the canonical reference.
-
-Other people may want to define variants on these "Allele" sequences.  It would
-be possible to write code to map those onto the reference graph.  This could
-support mapping variants between coordinate systems.  There has been interesting
-discussion about this in the context of dbSNP and representation of variation on
-multiple references.
-*/
 
 } // end of protocol

--- a/src/main/resources/avro/wip/variationreferencemethods.avdl
+++ b/src/main/resources/avro/wip/variationreferencemethods.avdl
@@ -1,0 +1,533 @@
+@namespace("org.ga4gh.wip")
+protocol VariationReferenceMethods {
+
+/*
+Methods for working with a `VariationReference` (a graph that functions as a
+reference) and `CallSets` on samples relative to such a reference.
+*/
+
+import idl "../common.avdl";
+import idl "variationReference.avdl";
+
+/****************  /graph/variationreferences/search  *******************/
+/**
+This request maps to the body of `POST /graph/variationreferences/search`
+as JSON.
+*/
+record SearchVariationReferencesRequest {
+  /**
+  If present, return the variation references which match any of the given
+  `md5checksum`s. See `VariationReference::md5checksum` for details.
+  */
+  array<string> md5checksums = [];
+
+  /**
+  If present, return variation references for which the accession
+  matches this string. Best to give a version number (e.g. `GCF_000001405.26`).
+  If only the main accession number is given then all records with
+  that main accession will be returned, whichever version.
+  Note that different versions will have different sequences.
+  */
+  array<string> accessions = [];
+
+  /**
+  If nonempty, return reference sets for which the `assemblyId`
+  contains this string.
+  */
+  array<string> assemblyIds = [];
+
+  /**
+  Specifies the maximum number of results to return in a single page.
+  If unspecified, a system default will be used.
+  */
+  union { null, int } pageSize = null;
+
+  /**
+  The continuation token, which is used to page through large result sets.
+  To get the next page of results, set this parameter to the value of
+  `nextPageToken` from the previous response.
+  */
+  union { null, string } pageToken = null;
+}
+
+/**
+This is the response from `POST /graph/variationreferences/search`
+expressed as JSON.
+*/
+record SearchVariationReferencesResponse {
+  /** The list of matching variation references. */
+  array<VariationReference> variationReferences = [];
+
+  /**
+  The continuation token, which is used to page through large result sets.
+  Provide this value in a subsequent request to return the next page of
+  results. This field will be empty if there aren't any additional results.
+  */
+  union { null, string } nextPageToken = null;
+}
+
+/**
+Gets a list of `VariationReference`s matching the search criteria.
+
+`POST /graph/variationreferences/search` must accept a JSON version of
+`SearchVariationReferencesRequest` as the post body and will return a JSON
+version of `SearchVariationReferencesResponse`.
+*/
+SearchVariationReferencesResponse searchVariationReferences(
+    /**
+    This request maps to the body of `POST /graph/variationreferences/search`
+    as JSON.
+    */
+    SearchVariationReferencesRequest request) throws org.ga4gh.GAException;
+
+/******************  /graph/datasets/search  *********************/
+/**
+This request maps to the body of `POST /graph/datasets/search` as JSON.
+*/
+record SearchDatasetsRequest {
+
+  // All you can do with datasets is enumerate which ones are available.
+
+  /**
+  Specifies the maximum number of results to return in a single page.
+  If unspecified, a system default will be used.
+  */
+  union { null, int } pageSize = null;
+
+  /**
+  The continuation token, which is used to page through large result sets.
+  To get the next page of results, set this parameter to the value of
+  `nextPageToken` from the previous response.
+  */
+  union { null, string } pageToken = null;
+}
+
+/**
+This is the response from `POST /graph/datasets/search` expressed as JSON.
+*/
+record SearchDatasetsResponse {
+  /** The list of datasets. */
+  array<string> datasetIds = [];
+
+  /**
+  The continuation token, which is used to page through large result sets.
+  Provide this value in a subsequent request to return the next page of
+  results. This field will be empty if there aren't any additional results.
+  */
+  union { null, string } nextPageToken = null;
+}
+
+/**
+Gets a list of dataset IDs accessible through the API.
+
+`POST /graph/datasets/search` must accept a JSON version of
+`SearchDatasetsRequest` as the post body and will return a JSON version
+of `SearchDatasetsResponse`.
+*/
+SearchDatasetsResponse searchDatasets(
+    /**
+    This request maps to the body of `POST /graph/datasets/search` as JSON.
+    */
+    SearchDatasetsRequest request) throws org.ga4gh.GAException;
+
+/******************  /graph/variantsets/search  *********************/
+/**
+This request maps to the body of `POST /graph/variantsets/search` as JSON.
+*/
+record SearchVariantSetsRequest {
+
+  /**
+  If nonempty, will restrict the query to variant sets within the
+  given datasets.
+  */
+  array<string> datasetIds = [];
+
+  /**
+  If nonempty, will restrict the query to variant sets with IDs on this list.
+  */
+  array<string> variantSetIds = [];
+  
+  /**
+  If nonempty, will restrict the query to variant sets on one of the given
+  `VariationReference`s.
+  */
+  array<string> variationReferenceIds = [];
+
+  /**
+  Specifies the maximum number of results to return in a single page.
+  If unspecified, a system default will be used.
+  */
+  union { null, int } pageSize = null;
+
+  /**
+  The continuation token, which is used to page through large result sets.
+  To get the next page of results, set this parameter to the value of
+  `nextPageToken` from the previous response.
+  */
+  union { null, string } pageToken = null;
+}
+
+/**
+This is the response from `POST /graph/variantsets/search` expressed as JSON.
+*/
+record SearchVariantSetsResponse {
+  /** The list of matching variants. */
+  array<Variant> variants = [];
+
+  /**
+  The continuation token, which is used to page through large result sets.
+  Provide this value in a subsequent request to return the next page of
+  results. This field will be empty if there aren't any additional results.
+  */
+  union { null, string } nextPageToken = null;
+}
+
+/**
+Gets a list of `VariantSet`s matching the search criteria.
+
+`POST /graph/variantsets/search` must accept a JSON version of
+`SearchVariantSetsRequest` as the post body and will return a JSON version
+of `SearchVariantSetsResponse`.
+*/
+SearchVariantSetsResponse searchVariantSets(
+    /**
+    This request maps to the body of `POST /graph/variantsets/search` as JSON.
+    */
+    SearchVariantSetsRequest request) throws org.ga4gh.GAException;
+
+/******************  /graph/variants/search  *********************/
+/** This request maps to the body of `POST /graph/variants/search` as JSON. */
+record SearchVariantsRequest {
+
+  /**
+  If nonempty, only return variants defined in one of the specified
+  `VariationReference`s.
+  */
+  array<string> variationReferenceIds = [];
+
+  /**
+  If nonempty, only return variants defined or with calls in one of the
+  specified `VariantSet`s.
+  */
+  array<string> variantSetIds = [];
+
+  /**
+  If nonempty, only return the variants with IDs on this list.
+  */
+  array<string> variantIds = [];
+  
+  /**
+  If nonempty, only return variants joined onto at least one variant with an IDs
+  on this list.
+  */
+  array<string> parentVariantIds = [];
+
+  /**
+  If nonempty, only return the variants that have one of these strings as a
+  name.
+  */
+  array<string> variantNames = [];
+
+  /**
+  Specifies the maximum number of results to return in a single page.
+  If unspecified, a system default will be used.
+  */
+  union { null, int } pageSize = null;
+
+  /**
+  The continuation token, which is used to page through large result sets.
+  To get the next page of results, set this parameter to the value of
+  `nextPageToken` from the previous response.
+  */
+  union { null, string } pageToken = null;
+}
+
+/**
+This is the response from `POST /graph/variants/search` expressed as JSON.
+*/
+record SearchVariantsResponse {
+  /** The list of matching variants. */
+  array<Variant> variants = [];
+
+  /**
+  The continuation token, which is used to page through large result sets.
+  Provide this value in a subsequent request to return the next page of
+  results. This field will be empty if there aren't any additional results.
+  */
+  union { null, string } nextPageToken = null;
+}
+
+/**
+Gets a list of `Variant`s matching the search criteria.
+
+`POST /graph/variants/search` must accept a JSON version of
+`SearchVariantsRequest` as the post body and will return a JSON version
+of `SearchVariantsResponse`.
+*/
+SearchVariantsResponse searchVariants(
+    /**
+    This request maps to the body of `POST /graph/variants/search` as JSON.
+    */
+    SearchVariantsRequest request) throws org.ga4gh.GAException;
+    
+/******************  /graph/alleles/search  *********************/
+/** This request maps to the body of `POST /graph/alleles/search` as JSON. */
+record SearchAllelesRequest {
+
+  /**
+  If nonempty, only return `Allele`s with IDs on this list.
+  */
+  array<string> alleleIds = [];
+
+  /**
+  If nonempty, only return `Allele`s defined or with calls in one of the
+  specified `VariantSet`s.
+  */
+  array<string> variantSetIds = [];
+
+  /**
+  If nonempty, only return `Allele`s including `Variant`s with IDs on this list.
+  */
+  array<string> variantIds = [];
+
+  /**
+  Specifies the maximum number of results to return in a single page.
+  If unspecified, a system default will be used.
+  */
+  union { null, int } pageSize = null;
+
+  /**
+  The continuation token, which is used to page through large result sets.
+  To get the next page of results, set this parameter to the value of
+  `nextPageToken` from the previous response.
+  */
+  union { null, string } pageToken = null;
+}
+
+/**
+This is the response from `POST /graph/alleles/search` expressed as JSON.
+*/
+record SearchAllelesResponse {
+  /** The list of matching `Allele`s. */
+  array<Allele> alleles = [];
+
+  /**
+  The continuation token, which is used to page through large result sets.
+  Provide this value in a subsequent request to return the next page of
+  results. This field will be empty if there aren't any additional results.
+  */
+  union { null, string } nextPageToken = null;
+}
+
+/**
+Gets a list of `Allele`s matching the search criteria.
+
+`POST /graph/alleles/search` must accept a JSON version of
+`SearchAllelesRequest` as the post body and will return a JSON version
+of `SearchAllelesResponse`.
+*/
+SearchAllelesResponse searchAlleles(
+    /**
+    This request maps to the body of `POST /graph/alleles/search` as JSON.
+    */
+    SearchAllelesRequest request) throws org.ga4gh.GAException;
+
+/******************  /graph/callsets/search  *********************/
+/** This request maps to the body of `POST /graph/callsets/search` as JSON. */
+record SearchCallSetsRequest {
+
+  /**
+  If nonempty, only return the `CallSet`s with IDs on this list.
+  */
+  array<string> callSetIds = [];
+
+  /**
+  If nonempty, only return call sets for which a substring of the name matches
+  one of these strings.
+  */
+  array<string> nameSubstrings = [];
+
+  /**
+  If nonempty, will restrict the query to call sets with calls in one of the
+  given variant sets.
+  */
+  array<string> variantSetIds = [];
+
+  /**
+  If nonempty, return only `CallSet`s with one of these sampleIds.
+  */
+  array<string> sampleIds = [];
+
+  /**
+  If nonempty, return only `CallSet`s with one of these types.
+  */
+  array<CallSetType> callSetTypes = [];
+
+  /**
+  Specifies the maximum number of results to return in a single page.
+  If unspecified, a system default will be used.
+  */
+  union { null, int } pageSize = null;
+
+  /**
+  The continuation token, which is used to page through large result sets.
+  To get the next page of results, set this parameter to the value of
+  `nextPageToken` from the previous response.
+  */
+  union { null, string } pageToken = null;
+}
+
+/**
+This is the response from `POST /graph/callsets/search` expressed as JSON.
+*/
+record SearchCallSetsResponse {
+  /** The list of matching call sets. */
+  array<CallSet> callSets = [];
+
+  /**
+  The continuation token, which is used to page through large result sets.
+  Provide this value in a subsequent request to return the next page of
+  results. This field will be empty if there aren't any additional results.
+  */
+  union { null, string } nextPageToken = null;
+}
+
+/**
+Gets a list of `CallSet` matching the search criteria.
+
+`POST /graph/callsets/search` must accept a JSON version of
+`SearchCallSetsRequest` as the post body and will return a JSON version of
+`SearchCallSetsResponse`.
+*/
+SearchCallSetsResponse searchCallSets(
+    /**
+    This request maps to the body of `POST /graph/callsets/search` as JSON.
+    */
+    SearchCallSetsRequest request) throws org.ga4gh.GAException;
+
+/******************  /graph/calls/search  *********************/
+/** This request maps to the body of `POST /graph/calls/search` as JSON. */
+record SearchCallsRequest {
+
+  /**
+  If nonempty, only return the `Call`s in these `CallSet`s.
+  */
+  array<string> callSetIds = [];
+
+  /**
+  If nonempty, return only `Call`s in these `VariantSet`s.
+  */
+  array<string> variantSetIds = [];
+  
+  /**
+  If nonempty, return only `Call`s involving one of the specified `Allele`s.
+  */
+  array<string> alleleIds = [];
+
+  /**
+  Specifies the maximum number of results to return in a single page.
+  If unspecified, a system default will be used.
+  */
+  union { null, int } pageSize = null;
+
+  /**
+  The continuation token, which is used to page through large result sets.
+  To get the next page of results, set this parameter to the value of
+  `nextPageToken` from the previous response.
+  */
+  union { null, string } pageToken = null;
+}
+
+/**
+This is the response from `POST /graph/calls/search` expressed as JSON.
+*/
+record SearchCallsResponse {
+  /** The list of matching calls. */
+  array<Call> calls = [];
+
+  /**
+  The continuation token, which is used to page through large result sets.
+  Provide this value in a subsequent request to return the next page of
+  results. This field will be empty if there aren't any additional results.
+  */
+  union { null, string } nextPageToken = null;
+}
+
+/**
+Gets a list of `Call` matching the search criteria.
+
+`POST /graph/calls/search` must accept a JSON version of
+`SearchCallsRequest` as the post body and will return a JSON version of
+`SearchCallsResponse`.
+*/
+SearchCallsResponse searchCalls(
+    /** This request maps to the body of `POST /graph/calls/search` as JSON. */
+    SearchCallsRequest request) throws org.ga4gh.GAException;
+
+/******************  /graph/allelescaffolds/search  *********************/
+/**
+This request maps to the body of `POST /graph/allelescaffolds/search` as JSON.
+*/
+record SearchAlleleScaffoldsRequest {
+
+  /**
+  If nonempty, return only `AlleleScaffold`s in one of the specified `CallSet`s.
+  */
+  array<string> callSetIds = [];
+  
+  /**
+  If nonempty, return only `AlleleScaffold`s in one of the specified 
+  `VariantSet`s.
+  */
+  array<string> variantSetIds = [];
+  
+  /**
+  If nonempty, return only `AlleleScaffold`s involving one of the specified
+  `Allele`s.
+  */
+  array<string> alleleIds = [];
+
+  /**
+  Specifies the maximum number of results to return in a single page.
+  If unspecified, a system default will be used.
+  */
+  union { null, int } pageSize = null;
+
+  /**
+  The continuation token, which is used to page through large result sets.
+  To get the next page of results, set this parameter to the value of
+  `nextPageToken` from the previous response.
+  */
+  union { null, string } pageToken = null;
+}
+
+/**
+This is the response from `POST /graph/allelescaffolds/search` expressed as JSON.
+*/
+record SearchAlleleScaffoldsResponse {
+  /** The list of `AlleleScaffold`s. */
+  array<AlleleScaffold> alleleScaffolds = [];
+
+  /**
+  The continuation token, which is used to page through large result sets.
+  Provide this value in a subsequent request to return the next page of
+  results. This field will be empty if there aren't any additional results.
+  */
+  union { null, string } nextPageToken = null;
+}
+
+/**
+Gets a list of traversal IDs matching the search criteria.
+
+`POST /graph/allelescaffolds/search` must accept a JSON version of
+`SearchAlleleScaffoldsRequest` as the post body and will return a JSON
+version of `SearchAlleleScaffoldsResponse`.
+*/
+SearchAlleleScaffoldsResponse searchAlleleScaffolds(
+    /**
+    This request maps to the body of `POST /graph/allelescaffolds/search` as
+    JSON.
+    */
+    SearchAlleleScaffoldsRequest request) throws org.ga4gh.GAException;
+
+}


### PR DESCRIPTION
Pulls some features of both the References and Variants data models into the existing `variationReference.avdl`, and adds a `variationreferencemethods.avdl` to define an API for it.