### PR TITLE
Fixed schemas for non-null default values.

### DIFF
--- a/src/main/resources/avro/readmethods.avdl
+++ b/src/main/resources/avro/readmethods.avdl
@@ -34,10 +34,10 @@ record SearchReadsRequest {
   The start position (0-based) of this query.
   If a reference is specified, this defaults to 0.
   Genomic positions are non-negative integers less than reference length.
-  Requests spanning the join of circular genomes are represented as 
+  Requests spanning the join of circular genomes are represented as
   two requests one on each side of the join (position 0).
   */
-  union { null, long } start = 0;
+  union { long, null } start = 0;
 
   /**
   The end position (0-based, exclusive) of this query.

--- a/src/main/resources/avro/reads.avdl
+++ b/src/main/resources/avro/reads.avdl
@@ -206,10 +206,10 @@ record ReadAlignment {
   The orientation and the distance between reads from the fragment are
   consistent with the sequencing protocol (extension to SAM flag 0x2)
   */
-  union { null, boolean } properPlacement = false;
+  union { boolean, null } properPlacement = false;
 
   /** The fragment is a PCR or optical duplicate (SAM flag 0x400) */
-  union { null, boolean } duplicateFragment = false;
+  union { boolean, null } duplicateFragment = false;
 
   /** The number of reads in the fragment (extension to SAM flag 0x1) */
   union { null, int } numberReads = null;
@@ -226,7 +226,7 @@ record ReadAlignment {
   union { null, int } readNumber = null;
 
   /** SAM flag 0x200 */
-  union { null, boolean } failedVendorQualityChecks = false;
+  union { boolean, null } failedVendorQualityChecks = false;
 
   /**
   The linear alignment for this alignment record. This field will be
@@ -243,7 +243,7 @@ record ReadAlignment {
   By convention, each read has one and only one alignment where both
   secondaryAlignment and supplementaryAlignment are false.
   */
-  union { null, boolean } secondaryAlignment = false;
+  union { boolean, null } secondaryAlignment = false;
 
   /**
   Whether this alignment is supplementary. Equivalent to SAM flag 0x800.
@@ -258,7 +258,7 @@ record ReadAlignment {
   The `alignedSequence` and `alignedQuality` fields in the alignment record will
   only represent the bases for its respective linear alignment.
   */
-  union { null, boolean } supplementaryAlignment = false;
+  union { boolean, null } supplementaryAlignment = false;
 
   /**
   The bases of the read sequence contained in this alignment record.


### PR DESCRIPTION
The default value for unions in Avro must be instances of the first schema. Therefore, we need to change things like  

`union { null, long } start = 0;`

to 

`union { long, null } start = 0;`
