### PR TITLE
Upping pom.xml version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
   <groupId>org.ga4gh</groupId>
   <artifactId>ga4gh-format</artifactId>
   <packaging>jar</packaging>
-  <version>0.1.0-SNAPSHOT</version>
+  <version>0.6.0-SNAPSHOT</version>
 
   <name>GA4GH: Schemas</name>
   <description>Data models and APIs for Genomic data.</description>


### PR DESCRIPTION
I'm setting the version in `pom.xml` to 0.6.0-SNAPSHOT, meaning we're currently in the process of developing version 0.6.0 of the schemas. We definitely have to have a version greater than 0.5.1, since that's our latest release, and since then we've made a number of potentially breaking changes, like stripping the "GA" prefixes off of everything, so I figured we would want to start with the 0.6 series.

In the future, when we do a release we ought to set this to exactly the version we release (so the tagged v0.6.0 release should have 0.6.0 here). The tagged v0.5.1 reports itself as "0.1.0-SNAPSHOT", which is a bit of a problem if anyone wants to depend on our compiled schema JARs.

Closes #197.
