### PR TITLE
Better array semantics for search requests

### DIFF
--- a/src/main/resources/avro/readmethods.avdl
+++ b/src/main/resources/avro/readmethods.avdl
@@ -14,7 +14,7 @@ to `ReferenceSet`s containing that same `Reference`. If no reference is
 specified, all `ReadGroup`s must be aligned to the same `ReferenceSet`.
 */
 record SearchReadsRequest {
-  /** If specified, restrict this query to reads within the given readgroups. */
+  /** If nonempty, restrict this query to reads within the given readgroups. */
   array<string> readGroupIds = [];
 
   /**

--- a/src/main/resources/avro/referencemethods.avdl
+++ b/src/main/resources/avro/referencemethods.avdl
@@ -31,13 +31,13 @@ as JSON.
 */
 record SearchReferenceSetsRequest {
   /**
-  If present, return the reference sets which match any of the given
+  If nonempty, return the reference sets which match any of the given
   `md5checksum`s. See `ReferenceSet::md5checksum` for details.
   */
   array<string> md5checksums = [];
 
   /**
-  If present, return reference sets for which the accession
+  If nonempty, return reference sets for which the accession
   matches this string. Best to give a version number (e.g. `GCF_000001405.26`).
   If only the main accession number is given then all records with
   that main accession will be returned, whichever version.
@@ -118,7 +118,7 @@ record SearchReferencesRequest {
   union { null, string } referenceSetId = null;
 
   /**
-  If present, return references which match any of the given `md5checksums`.
+  If nonempty, return references which match any of the given `md5checksums`.
   See `Reference::md5checksum` for details.
   */
   array<string> md5checksums = [];
@@ -130,7 +130,7 @@ record SearchReferencesRequest {
   array<string> parentReferenceIds = [];
 
   /**
-  If present, return references for which the accession
+  If nonempty, return references for which the accession
   matches this string. Best to give a version number e.g. `GCF_000001405.26`.
   If only the main accession number is given then all records with
   that main accession will be returned, whichever version.

--- a/src/main/resources/avro/variantmethods.avdl
+++ b/src/main/resources/avro/variantmethods.avdl
@@ -8,7 +8,7 @@ import idl "variants.avdl";
 /** This request maps to the body of `POST /variantsets/search` as JSON. */
 record SearchVariantSetsRequest {
   /**
-  If specified, will restrict the query to variant sets within the
+  If nonempty, will restrict the query to variant sets within the
   given datasets.
   */
   array<string> datasetIds = [];
@@ -314,7 +314,7 @@ org.ga4gh.models.Allele getAllele(
 /** This request maps to the body of `POST /callsets/search` as JSON. */
 record SearchCallSetsRequest {
   /**
-  If specified, will restrict the query to call sets within the
+  If nonempty, will restrict the query to call sets within the
   given variant sets.
   */
   array<string> variantSetIds = [];


### PR DESCRIPTION
This takes the changes I made in #198 to arrays on search request objects, and pulls them out as their own pull request. A lot of them had comments reading "If specified..." or "If present...", but were not actually optional (i.e. not unioned with null). I changed these to "If nonempty" instead. If you pass an empty array, it means you don't want to use that particular filter in your query.