### PR TITLE
Adding ability to search references by name.

### DIFF
--- a/src/main/resources/avro/referencemethods.avdl
+++ b/src/main/resources/avro/referencemethods.avdl
@@ -139,6 +139,11 @@ record SearchReferencesRequest {
   array<string> accessions = [];
 
   /**
+  If nonempty, return references that have one of the specified names.
+  */
+  array<string> referenceNames = [];
+
+  /**
   Specifies the maximum number of results to return in a single page.
   If unspecified, a system default will be used.
   */

--- a/src/main/resources/avro/referencemethods.avdl
+++ b/src/main/resources/avro/referencemethods.avdl
@@ -139,7 +139,8 @@ record SearchReferencesRequest {
   array<string> accessions = [];
 
   /**
-  If nonempty, return references that have one of the specified names.
+  If nonempty, return references that have one of the specified names. The name
+  specified must match the reference's name exactly, and is case sensitive.
   */
   array<string> referenceNames = [];
 


### PR DESCRIPTION
If we end up with many alt haplotype `Reference`s in a `ReferenceSet`, we might want to pull down, say, the primary path X chromosome named "X" without enumerating through the whole `ReferenceSet`.