### PR TITLE
Move models and RPC methods out of root package

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -66,3 +66,6 @@ target/
 #********** Travis CI **********
 
 !.travis.yml
+
+#********** IntelliJ files ******
+*.iml

--- a/GeneratingDocumentation.md
+++ b/GeneratingDocumentation.md
@@ -10,12 +10,12 @@ Assuming that you have [Node.js](http://nodejs.org/) and [NPM](https://www.npmjs
 npm install avrodoc --global
 ```
 
-The `avrodoc` tool expects Avro schemas in JSON format. The Maven plugin we use for generation of artifacts and tests does not produce the JSON formatted Avro schema. You will need to download the [Avro tools JAR file](http://www.us.apache.org/dist/avro/avro-1.7.6/java/avro-tools-1.7.6.jar)
+The `avrodoc` tool expects Avro schemas in JSON format. The Maven plugin we use for generation of artifacts and tests does not produce the JSON formatted Avro schema. You will need to download the [Avro tools JAR file](http://www.us.apache.org/dist/avro/avro-1.7.7/java/avro-tools-1.7.7.jar)
 
 ```shell
 # For a full list of mirrors, see http://www.apache.org/dyn/closer.cgi/avro/
 
-curl -o /opt/avro-tools.jar  http://www.us.apache.org/dist/avro/avro-1.7.6/java/avro-tools-1.7.6.jar
+curl -o /opt/avro-tools.jar  http://www.us.apache.org/dist/avro/avro-1.7.7/java/avro-tools-1.7.7.jar
 
 ```
 
@@ -39,7 +39,7 @@ avrodoc input.avpr > output.html
 npm install avrodoc --global
 
 # download the Avro tools
-curl -o /opt/avro-tools.jar  http://www.us.apache.org/dist/avro/avro-1.7.6/java/avro-tools-1.7.6.jar
+curl -o /opt/avro-tools.jar  http://www.us.apache.org/dist/avro/avro-1.7.7/java/avro-tools-1.7.7.jar
 
 # assumes that $CWD is the ga4gh/schemas project dir
 

--- a/src/main/resources/avro/beacon.avdl
+++ b/src/main/resources/avro/beacon.avdl
@@ -1,4 +1,4 @@
-@namespace("org.ga4gh")
+@namespace("org.ga4gh.beacon")
 
 protocol BEACON {
 

--- a/src/main/resources/avro/common.avdl
+++ b/src/main/resources/avro/common.avdl
@@ -1,20 +1,9 @@
-@namespace("org.ga4gh")
+@namespace("org.ga4gh.models")
 /**
 This protocol defines common types used in the other GA4GH protocols. It does
 not have any methods; it is merely a library of types.
 */
 protocol Common {
-
-/**
-A general exception type.
-*/
-error GAException {
-  /** The error message */
-  string message;
-
-  /** The numerical error code */
-  int errorCode = -1;
-}
 
 /**
 An abstraction for referring to a genomic position, in relation to some

--- a/src/main/resources/avro/methods.avdl
+++ b/src/main/resources/avro/methods.avdl
@@ -1,0 +1,18 @@
+@namespace("org.ga4gh.methods")
+
+protocol RPC {
+
+/**
+A general exception type.
+*/
+error GAException {
+  /** The error message */
+  string message;
+
+  /** The numerical error code */
+  int errorCode = -1;
+}
+
+
+
+}

--- a/src/main/resources/avro/readmethods.avdl
+++ b/src/main/resources/avro/readmethods.avdl
@@ -1,7 +1,8 @@
-@namespace("org.ga4gh")
+@namespace("org.ga4gh.methods")
 protocol ReadMethods {
 
 import idl "common.avdl";
+import idl "methods.avdl";
 import idl "reads.avdl";
 
 /******************  /reads/search  *********************/
@@ -66,7 +67,7 @@ record SearchReadsResponse {
   The list of matching alignment records, sorted by position.
   Unmapped reads, which have no position, are returned last.
   */
-  array<ReadAlignment> alignments = [];
+  array<org.ga4gh.models.ReadAlignment> alignments = [];
 
   /**
   The continuation token, which is used to page through large result sets.
@@ -115,7 +116,7 @@ record SearchReadGroupSetsRequest {
 /** This is the response from `POST /readgroupsets/search` expressed as JSON. */
 record SearchReadGroupSetsResponse {
   /** The list of matching read group sets. */
-  array<ReadGroupSet> readGroupSets = [];
+  array<org.ga4gh.models.ReadGroupSet> readGroupSets = [];
 
   /**
   The continuation token, which is used to page through large result sets.
@@ -140,10 +141,10 @@ SearchReadGroupSetsResponse searchReadGroupSets(
 
 /****************  /readgroupsets/{id}  *******************/
 /**
-Gets a `ReadGroupSet` by ID.
+Gets a `org.ga4gh.models.ReadGroupSet` by ID.
 `GET /readgroupsets/{id}` will return a JSON version of `ReadGroupSet`.
 */
-ReadGroupSet getReadGroupSet(
+org.ga4gh.models.ReadGroupSet getReadGroupSet(
     /**
     The ID of the `ReadGroupSet`.
     */
@@ -154,7 +155,7 @@ ReadGroupSet getReadGroupSet(
 Gets a `Dataset` by ID.
 `GET /datasets/{id}` will return a JSON version of `Dataset`.
 */
-Dataset getDataset(
+org.ga4gh.models.Dataset getDataset(
     /**
     The ID of the `Dataset`.
     */

--- a/src/main/resources/avro/reads.avdl
+++ b/src/main/resources/avro/reads.avdl
@@ -1,4 +1,4 @@
-@namespace("org.ga4gh")
+@namespace("org.ga4gh.models")
 
 /**
 This file defines the objects used to represent a hierarchy of reads and alignments:

--- a/src/main/resources/avro/referencemethods.avdl
+++ b/src/main/resources/avro/referencemethods.avdl
@@ -1,7 +1,8 @@
-@namespace("org.ga4gh")
+@namespace("org.ga4gh.methods")
 protocol ReferenceMethods {
 
 import idl "common.avdl";
+import idl "methods.avdl";
 import idl "references.avdl";
 
 /****************  /referencesets/search  *******************/
@@ -51,7 +52,7 @@ expressed as JSON.
 */
 record SearchReferenceSetsResponse {
   /** The list of matching reference sets. */
-  array<ReferenceSet> referenceSets = [];
+  array<org.ga4gh.models.ReferenceSet> referenceSets = [];
 
   /**
   The continuation token, which is used to page through large result sets.
@@ -80,7 +81,7 @@ SearchReferenceSetsResponse searchReferenceSets(
 Gets a `ReferenceSet` by ID.
 `GET /referencesets/{id}` will return a JSON version of `ReferenceSet`.
 */
-ReferenceSet getReferenceSet(
+org.ga4gh.models.ReferenceSet getReferenceSet(
     /**
     The ID of the `ReferenceSet`.
     */
@@ -131,7 +132,7 @@ This is the response from `POST /references/search` expressed as JSON.
 */
 record SearchReferencesResponse {
   /** The list of matching references. */
-  array<Reference> references = [];
+  array<org.ga4gh.models.Reference> references = [];
 
   /**
   The continuation token, which is used to page through large result sets.
@@ -160,7 +161,7 @@ SearchReferencesResponse searchReferences(
 Gets a `Reference` by ID.
 `GET /references/{id}` will return a JSON version of `Reference`.
 */
-Reference getReference(
+org.ga4gh.models.Reference getReference(
     /**
     The ID of the `Reference`.
     */

--- a/src/main/resources/avro/references.avdl
+++ b/src/main/resources/avro/references.avdl
@@ -1,4 +1,4 @@
-@namespace("org.ga4gh")
+@namespace("org.ga4gh.models")
 
 protocol References {
 

--- a/src/main/resources/avro/variantmethods.avdl
+++ b/src/main/resources/avro/variantmethods.avdl
@@ -1,6 +1,7 @@
-@namespace("org.ga4gh")
+@namespace("org.ga4gh.methods")
 protocol VariantMethods {
 
+import idl "methods.avdl";
 import idl "variants.avdl";
 
 /******************  /variantsets/search  *********************/
@@ -29,7 +30,7 @@ record SearchVariantSetsRequest {
 /** This is the response from `POST /variantsets/search` expressed as JSON. */
 record SearchVariantSetsResponse {
   /** The list of matching variant sets. */
-  array<VariantSet> variantSets = [];
+  array<org.ga4gh.models.VariantSet> variantSets = [];
 
   /**
     The continuation token, which is used to page through large result sets.
@@ -108,7 +109,7 @@ record SearchVariantsResponse {
   of the calls on each `Variant`. The number of results will also be
   the same.
   */
-  array<Variant> variants = [];
+  array<org.ga4gh.models.Variant> variants = [];
 
   /**
   The continuation token, which is used to page through large result sets.
@@ -160,7 +161,7 @@ record SearchCallSetsRequest {
 /** This is the response from `POST /callsets/search` expressed as JSON. */
 record SearchCallSetsResponse {
   /** The list of matching call sets. */
-  array<CallSet> callSets = [];
+  array<org.ga4gh.models.CallSet> callSets = [];
 
   /**
   The continuation token, which is used to page through large result sets.
@@ -185,7 +186,7 @@ SearchCallSetsResponse searchCallSets(
 Gets a `CallSet` by ID.
 `GET /callsets/{id}` will return a JSON version of `CallSet`.
 */
-CallSet getCallSet(
+org.ga4gh.models.CallSet getCallSet(
     /**
     The ID of the `CallSet`.
     */

--- a/src/main/resources/avro/variants.avdl
+++ b/src/main/resources/avro/variants.avdl
@@ -1,4 +1,4 @@
-@namespace("org.ga4gh")
+@namespace("org.ga4gh.models")
 protocol Variants {
 
 import idl "common.avdl";

--- a/src/main/resources/avro/wip/metadata.avdl
+++ b/src/main/resources/avro/wip/metadata.avdl
@@ -1,4 +1,4 @@
-@namespace("org.ga4gh")
+@namespace("org.ga4gh.models")
 
 /**
 This protocol defines metadata used in the other GA4GH protocols.

--- a/src/main/resources/avro/wip/metadatamethods.avdl
+++ b/src/main/resources/avro/wip/metadatamethods.avdl
@@ -1,6 +1,7 @@
-@namespace("org.ga4gh")
+@namespace("org.ga4gh.methods")
 protocol MetadataMethods {
 
+import idl "methods.avdl";
 import idl "metadata.avdl";
 
 /******************  /individuals/search  *********************/
@@ -39,7 +40,7 @@ record SearchIndividualsResponse {
   /**
   The list of matching individuals.
    */
-  array<Individual> individuals = [];
+  array<org.ga4gh.models.Individual> individuals = [];
 
   /**
   The continuation token, which is used to page through large result sets.
@@ -94,7 +95,7 @@ record SearchSamplesResponse {
   /**
   The list of matching samples.
    */
-  array<Sample> samples = [];
+  array<org.ga4gh.models.Sample> samples = [];
 
   /**
   The continuation token, which is used to page through large result sets.
@@ -146,7 +147,7 @@ record SearchExperimentsResponse {
   /**
   The list of matching experiments.
    */
-  array<Experiment> experiments = [];
+  array<org.ga4gh.models.Experiment> experiments = [];
 
   /**
   The continuation token, which is used to page through large result sets.
@@ -200,7 +201,7 @@ record SearchIndividualGroupsResponse {
   /**
   The list of matching individual groups.
    */
-  array<IndividualGroup> individualGroups = [];
+  array<org.ga4gh.models.IndividualGroup> individualGroups = [];
 
   /**
   The continuation token, which is used to page through large result sets.
@@ -254,7 +255,7 @@ record SearchAnalysesResponse {
   /**
   The list of matching analyses.
    */
-  array<Analysis> analyses = [];
+  array<org.ga4gh.models.Analysis> analyses = [];
 
   /**
   The continuation token, which is used to page through large result sets.


### PR DESCRIPTION
This updates the namespace to place the models into the
org.ga4gh.models package and RPC methods into the
org.ga4gh.rpc package. Previously, all objects were on
the root package org.ga4gh.
