### PR TITLE
Specifying that fast-forwards on topic branches need pull requests

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -33,7 +33,7 @@ When you submit or change your pull request, the Travis build system will automa
 
 If you wish to collaborate on a new feature with other GA4GH members, you can ask that a topic branch be created in this repository. Since Github does not allow pull requests against branches that do not yet exist, you will have to create an issue asking for the topic branch to be created.
 
-Once the topic branch exists, pull requests can be made against it in the usual way. It may also be brought up to date with new changes merged into master by anyone with commit access, if the changes produce merely a fast-forward merge. However, if changes from the master branch create a new merge commit, that commit needs to be reviewed in a pull request.
+Once the topic branch exists, pull requests can be made against it in the usual way. Pull requests which merely bring the branch up to date with master may be merged immediately by anyone, **if the changes produce merely a fast-forward merge**. However, if changes from the master branch create a new merge commit, that pull request needs to be reviewed.
 
 Changes made in a topic branch can be merged into master by creating and then [resolving in the normal way](#issue_resolution) a pull request against the master branch.
 


### PR DESCRIPTION
This should stop people pushing directly to topic branches and accidentally closing pull requests like #198.
