### PR TITLE
Change specification search of name search to exact name match

### DIFF
--- a/src/main/resources/avro/metadatamethods.avdl
+++ b/src/main/resources/avro/metadatamethods.avdl
@@ -14,8 +14,7 @@ record SearchIndividualsRequest {
   array<string> groupIds = [];
 
   /**
-  Only return individuals for which a substring of the name matches
-  this string.
+  Only return individuals with this name (case-sensitive, exact match).
   */
   union { null, string } name = null;
 
@@ -70,8 +69,7 @@ record SearchSamplesRequest {
   array<string> individualIds = [];
 
   /**
-  Only return samples for which a substring of the name matches
-  this string.
+  Only return samples with this name (case-sensitive, exact match).
   */
   union { null, string } name = null;
 
@@ -122,8 +120,7 @@ SearchSamplesResponse searchSamples(
 /** This request maps to the body of `POST /experiments/search` as JSON. */
 record SearchExperimentsRequest {
   /**
-  Only return experiments for which a substring of the name matches
-  this string.
+  Only return experiments with this name (case-sensitive, exact match).
   */
   union { null, string } name = null;
 
@@ -174,8 +171,7 @@ SearchExperimentsResponse searchExperiments(
 /** This request maps to the body of `POST /individualgroups/search` as JSON. */
 record SearchIndividualGroupsRequest {
   /**
-  Only return individual groups for which a substring of the name matches
-  this string.
+  Only return individual groups with this name (case-sensitive, exact match).
   */
   union { null, string } name = null;
 
@@ -230,8 +226,7 @@ SearchIndividualGroupsResponse searchIndividuals(
 /** This request maps to the body of `POST /analyses/search` as JSON. */
 record SearchAnalysesRequest {
   /**
-  Only return analyses for which a substring of the name matches
-  this string.
+  Only return analyses with this name (case-sensitive, exact match).
   */
   union { null, string } name = null;
 

--- a/src/main/resources/avro/readmethods.avdl
+++ b/src/main/resources/avro/readmethods.avdl
@@ -86,8 +86,7 @@ record SearchReadGroupSetsRequest {
   array<string> datasetIds = [];
 
   /**
-  Only return read group sets for which a substring of the name matches
-  this string.
+  Only return read group sets with this name (case-sensitive, exact match).
   */
   union { null, string } name = null;
 

--- a/src/main/resources/avro/referencemethods.avdl
+++ b/src/main/resources/avro/referencemethods.avdl
@@ -47,7 +47,7 @@ record SearchReferenceSetsRequest {
 
   /**
   If present, return reference sets for which the `assemblyId`
-  contains this string.
+  matches this string (case-sensitive, exact match).
   */
   union { null, string } assemblyId = null;
 

--- a/src/main/resources/avro/variantmethods.avdl
+++ b/src/main/resources/avro/variantmethods.avdl
@@ -140,8 +140,8 @@ record SearchVariantsRequest {
   /** Required. The IDs of the variant sets to search over. */
   array<string> variantSetIds = [];
 
-  /** Only return variants which have exactly this name. */
-  union { null, string } variantName = null;
+  /** Only return variants which have exactly this name (case-sensitive, exact match). */
+  union { null, string } name = null;
 
   /**
   Only return variant calls which belong to call sets with these IDs.
@@ -152,7 +152,7 @@ record SearchVariantsRequest {
 
   /**
   Only return variants with reference alleles on the reference with this name.
-  One of this field or `referenceId` is required.
+  One of this field or `referenceId` is required.  (case-sensitive, exact match)
   */
   union { null, string } referenceName = null;
 
@@ -320,8 +320,7 @@ record SearchCallSetsRequest {
   array<string> variantSetIds = [];
 
   /**
-  Only return call sets for which a substring of the name matches this
-  string.
+  Only return call sets with this name (case-sensitive, exact match).
   */
   union { null, string } name = null;
 


### PR DESCRIPTION
 Substring matching on searches is of limit value and is dangerous,
potentially producing inconsistent, difficult to predict results.  There was
no way to escape the substring matching behavior to get exact matches.  If
pattern searches are required, a separate parameter should be added that
supports regular expressions.

Also made variable search name parameter consistent.