### PR TITLE
Add getters for VariantSet and ReadGroup.

### DIFF
--- a/src/main/resources/avro/readmethods.avdl
+++ b/src/main/resources/avro/readmethods.avdl
@@ -142,6 +142,17 @@ org.ga4gh.models.ReadGroupSet getReadGroupSet(
   */
   string id) throws GAException;
 
+/****************  /readgroups/{id}  *******************/
+/**
+Gets a `org.ga4gh.models.ReadGroup` by ID.
+`GET /readgroups/{id}` will return a JSON version of `ReadGroup`.
+*/
+org.ga4gh.models.ReadGroup getReadGroup(
+  /**
+  The ID of the `ReadGroup`.
+  */
+  string id) throws GAException;
+
 /******************  /datasets/search  *********************/
 /**
 This request maps to the body of `POST /datasets/search` as JSON.
@@ -202,5 +213,5 @@ org.ga4gh.models.Dataset getDataset(
   The ID of the `Dataset`.
   */
   string id) throws GAException;
-  
+
 }

--- a/src/main/resources/avro/variantmethods.avdl
+++ b/src/main/resources/avro/variantmethods.avdl
@@ -51,6 +51,16 @@ SearchVariantSetsResponse searchVariantSets(
   /** This request maps to the body of `POST /variantsets/search` as JSON. */
   SearchVariantSetsRequest request) throws GAException;
 
+/**************** /variantsets/{id} *******************/
+/**
+Gets a `VariantSet` by ID.
+`GET /variantsets/{id}` will return a JSON version of `VariantSet`.
+*/
+org.ga4gh.models.VariantSet getVariantSet(
+  /**
+  The ID of the `VariantSet`.
+  */
+  string id) throws GAException;
 
 /******************  /variantsets/{id}/sequences/search  *********************/
 /**
@@ -220,7 +230,8 @@ as the post body and will return a JSON version of `SearchVariantsResponse`.
 SearchVariantsResponse searchVariants(
   /** This request maps to the body of `POST /variants/search` as JSON. */
   SearchVariantsRequest request) throws GAException;
-  /**************** /variants/{id} *******************/
+
+/**************** /variants/{id} *******************/
 /**
 Gets a `Variant` by ID.
 `GET /variants/{id}` will return a JSON version of `Variant`.


### PR DESCRIPTION
Fixes issue #245. These methods are required by the `ga2sam` and `ga2vcf` tools, which convert a subset of a `ReadGroup` and `VariantSet` into SAM and VCF formats, respectively.