### PR TITLE
renaming 'allele' to alternateBases and adding a field referenceBases

### DIFF
--- a/src/main/resources/avro/beacon.avdl
+++ b/src/main/resources/avro/beacon.avdl
@@ -10,12 +10,16 @@ protocol BEACON {
 A request for information about a specific site
 */
 record QueryResource {
-  /** Allele string. Use I<seq> for insertions and Dn for deletions, 
-      where <seq> is the nucleotide sequence inserted after position 
-      and n is a number of nucleotides deleted from the reference 
-      starting at position.  
+  /** 
+  The reference bases for this variant, starting from position, in the genome
+  describe by the field `reference`.  (see variants.avdl)
    */
-  string allele;
+  string referenceBases;
+
+  /** 
+  The bases that appear instead of the reference bases. (see variants.avdl)
+   */
+  string alternateBases;
 
   /** The chromosome of the request */
   string chromosome;

--- a/src/main/resources/avro/beacon.avdl
+++ b/src/main/resources/avro/beacon.avdl
@@ -11,8 +11,8 @@ A request for information about a specific site
 */
 record QueryResource {
   /** 
-  The reference bases for this variant, starting from position, in the genome
-  describe by the field `reference`.  (see variants.avdl)
+  The reference bases for this variant, starting from `position`, in the genome
+  described by the field `reference`.  (see variants.avdl)
    */
   string referenceBases;
 


### PR DESCRIPTION
Based on the discussion after mfiume's last pull request, adding a field referenceBases and renaming the allele field to alternateBases to make this API more similar to the variants API. Indels can now be specified just as in VCF and the variants API.