### PR TITLE
Rationalises the SearchObjectRequest semantics.

### DIFF
--- a/src/main/resources/avro/metadatamethods.avdl
+++ b/src/main/resources/avro/metadatamethods.avdl
@@ -8,10 +8,9 @@ import idl "metadata.avdl";
 /** This request maps to the body of `POST /individuals/search` as JSON. */
 record SearchIndividualsRequest {
   /**
-  If specified, restrict this query to individuals within the given
-  individual groups.
+  The Group to search.
   */
-  array<string> groupIds = [];
+  string groupId;
 
   /**
   Only return individuals with this name (case-sensitive, exact match).
@@ -52,8 +51,8 @@ record SearchIndividualsResponse {
 /**
 Gets a list of `Individual` matching the search criteria.
 
-`POST /individuals/search` must accept a JSON version of 
-`SearchIndividualsRequest` as the post body and will return a JSON version of 
+`POST /individuals/search` must accept a JSON version of
+`SearchIndividualsRequest` as the post body and will return a JSON version of
 `SearchIndividualsResponse`.
 */
 SearchIndividualsResponse searchIndividuals(
@@ -65,8 +64,10 @@ SearchIndividualsResponse searchIndividuals(
 /** This request maps to the body of `POST /samples/search` as JSON. */
 
 record SearchSamplesRequest {
-  /** If specified, restrict this query to samples for the given individuals. */
-  array<string> individualIds = [];
+  /**
+  The Individual to search.
+  */
+  string individualId;
 
   /**
   Only return samples with this name (case-sensitive, exact match).
@@ -107,8 +108,8 @@ record SearchSamplesResponse {
 /**
 Gets a list of `Sample` matching the search criteria.
 
-`POST /samples/search` must accept a JSON version of 
-`SearchSamplesRequest` as the post body and will return a JSON version of 
+`POST /samples/search` must accept a JSON version of
+`SearchSamplesRequest` as the post body and will return a JSON version of
 `SearchSamplesResponse`.
 */
 SearchSamplesResponse searchSamples(
@@ -158,8 +159,8 @@ record SearchExperimentsResponse {
 /**
 Gets a list of `Experiment` matching the search criteria.
 
-`POST /experiments/search` must accept a JSON version of 
-`SearchExperimentsRequest` as the post body and will return a JSON version of 
+`POST /experiments/search` must accept a JSON version of
+`SearchExperimentsRequest` as the post body and will return a JSON version of
 `SearchExperimentsResponse`.
 */
 SearchExperimentsResponse searchExperiments(

--- a/src/main/resources/avro/readmethods.avdl
+++ b/src/main/resources/avro/readmethods.avdl
@@ -14,8 +14,10 @@ to `ReferenceSet`s containing that same `Reference`. If no reference is
 specified, all `ReadGroup`s must be aligned to the same `ReferenceSet`.
 */
 record SearchReadsRequest {
-  /** If nonempty, restrict this query to reads within the given readgroups. */
-  array<string> readGroupIds = [];
+  /**
+  The ReadGroups to search. At least one readGroupId must be specified.
+  */
+  array<string> readGroupIds;
 
   /**
   The reference to query. Leaving blank returns results from all
@@ -82,8 +84,10 @@ SearchReadsResponse searchReads(
 /******************  /readgroupsets/search  *********************/
 /** This request maps to the body of `POST /readgroupsets/search` as JSON. */
 record SearchReadGroupSetsRequest {
-  /** The list of datasets to search. */
-  array<string> datasetIds = [];
+  /**
+  The dataset to search.
+  */
+  string datasetId;
 
   /**
   Only return read group sets with this name (case-sensitive, exact match).

--- a/src/main/resources/avro/sequenceAnnotationmethods.avdl
+++ b/src/main/resources/avro/sequenceAnnotationmethods.avdl
@@ -7,7 +7,7 @@ protocol SequenceAnnotationMethods {
   import idl "sequenceAnnotations.avdl";
 
   // FIXME: wiggle methods not defined.
-  
+
   /******************  /features/search  *********************/
 
   /**
@@ -15,16 +15,16 @@ protocol SequenceAnnotationMethods {
   */
   record SearchFeaturesRequest {
     /**
-    The annotation sets to search within. Either `featureSetIds` or
-    `parentIds` must be non-empty.
+    The annotation set to search within. Either `featureSetId` or
+    `parentId` must be non-empty.
     */
-    array<string> featureSetIds = [];
+    union { null, string } featureSetId;
 
     /**
     Restricts the search to direct children of the given parent `feature`
-    IDs. Either `featureSetIds` or `parentIds` must be non-empty.
+    ID. Either `featureSetId` or `parentId` must be non-empty.
     */
-    array<string> parentIds = [];
+    union { null, string } parentId;
 
     /**
     If specified, this query matches only annotations which overlap this path.

--- a/src/main/resources/avro/variantmethods.avdl
+++ b/src/main/resources/avro/variantmethods.avdl
@@ -8,10 +8,9 @@ import idl "variants.avdl";
 /** This request maps to the body of `POST /variantsets/search` as JSON. */
 record SearchVariantSetsRequest {
   /**
-  If nonempty, will restrict the query to variant sets within the
-  given datasets.
+  The Dataset to search.
   */
-  array<string> datasetIds = [];
+  string datasetId;
 
   /**
   Specifies the maximum number of results to return in a single page.
@@ -62,11 +61,95 @@ org.ga4gh.models.VariantSet getVariantSet(
   */
   string id) throws GAException;
 
+/******************  /variantsets/{id}/sequences/search  *********************/
+/**
+This request maps to the body of `POST /variantsets/{id}/sequences/search` as
+JSON.
+*/
+record SearchVariantSetSequencesRequest {
+  /**
+  Return `Segment`s describing novel sequences in the `VariantSet`
+  that are joined onto the sequence with the specified ID.
+  */
+  string parentId;
+
+  /**
+  Specifies the maximum number of results to return in a single page.
+  If unspecified, a system default will be used.
+  */
+  union { null, int } pageSize = null;
+
+  /**
+  The continuation token, which is used to page through large result sets.
+  To get the next page of results, set this parameter to the value of
+  `nextPageToken` from the previous response.
+  */
+  union { null, string } pageToken = null;
+}
+
+/**
+This is the response from `POST /variantsets/{id}/sequences/search` expressed as
+JSON.
+*/
+record SearchVariantSetSequencesResponse {
+  /**
+  The list of `Segment`s for matching sequences from the novel sequence graph
+  for the `VariantSet`.
+  */
+  array<org.ga4gh.models.Segment> segments = [];
+
+  /**
+  The continuation token, which is used to page through large result sets.
+  Provide this value in a subsequent request to return the next page of
+  results. This field will be empty if there aren't any additional results.
+  */
+  union { null, string } nextPageToken = null;
+}
+
+/**
+Gets `Segment`s covering the sequences that match the search criteria.
+
+`POST /variantsets/{id}/sequences/search` must accept a JSON version of
+`SearchVariantSetSequencesRequest` as the post body and will return a JSON
+version of `SearchVariantSetSequencesResponse`.
+*/
+SearchVariantSetSequencesResponse searchVariantSetSequences(
+  /**
+  The ID of the `VariantSet` which provides the novel sequences.
+  */
+  string variantSetId,
+  /**
+  This request maps to the body of `POST variantsets/{id}/sequences/search` as
+  JSON.
+  */
+  SearchVariantSetSequencesRequest request) throws GAException;
+
+/*****************  /variantsets/{id}/sequences/{id}  *******************/
+/**
+Gets a `Segment` describing a novel sequence in a `VariantSet`, by sequence
+ID.
+
+`GET /variantsets/{id}/sequences/{id}` will return a JSON version of a `Segment`
+covering the novel sequence with the given ID, and describing where it is
+joined onto its parent sequences.
+*/
+org.ga4gh.models.Segment getVariantSetSequence(
+  /**
+  The ID of the `VariantSet` which provides the novel sequence.
+  */
+  string variantSetId,
+  /**
+  The ID of the novel sequence to get a covering `Segment` for.
+  */
+  string sequenceId) throws GAException;
+
 /******************  /variants/search  *********************/
 /** This request maps to the body of `POST /variants/search` as JSON. */
 record SearchVariantsRequest {
-  /** Required. The IDs of the variant sets to search over. */
-  array<string> variantSetIds = [];
+  /**
+  The VariantSet to search.
+  */
+  string variantSetId;
 
   /** Only return variants which have exactly this name (case-sensitive, exact match). */
   union { null, string } name = null;
@@ -163,8 +246,10 @@ org.ga4gh.models.Variant getVariant(
 /******************  /alleles/search  *********************/
 /** This request maps to the body of `POST /alleles/search` as JSON. */
 record SearchAllelesRequest {
-  /** Required. The IDs of the variant sets to search over. */
-  array<string> variantSetIds = [];
+  /**
+  The VariantSet to search.
+  */
+  string variantSetId;
 
   /**
   Required. Only return `Allele`s on the sequence with this ID.
@@ -243,10 +328,9 @@ org.ga4gh.models.Allele getAllele(
 /** This request maps to the body of `POST /callsets/search` as JSON. */
 record SearchCallSetsRequest {
   /**
-  If nonempty, will restrict the query to call sets within the
-  given variant sets.
+  The VariantSet to search.
   */
-  array<string> variantSetIds = [];
+  string variantSetId;
 
   /**
   Only return call sets with this name (case-sensitive, exact match).
@@ -300,127 +384,4 @@ org.ga4gh.models.CallSet getCallSet(
   The ID of the `CallSet`.
   */
   string id) throws GAException;
-
-/****************** /calls/search *********************/
-/** This request maps to the body of `POST /calls/search` as JSON. */
-record SearchCallsRequest {
-
-  /**
-  If nonempty, only return the `Call`s in these `CallSet`s.
-  */
-  array<string> callSetIds = [];
-
-  /**
-  If nonempty, return only `Call`s in these `VariantSet`s.
-  */
-  array<string> variantSetIds = [];
-
-  /**
-  If nonempty, return only `Call`s associated with one of these `Variant`s.
-  */
-  array<string> variantIds = [];
-
-  /**
-  Specifies the maximum number of results to return in a single page.
-  If unspecified, a system default will be used.
-  */
-  union { null, int } pageSize = null;
-
-  /**
-  The continuation token, which is used to page through large result sets.
-  To get the next page of results, set this parameter to the value of
-  `nextPageToken` from the previous response.
-  */
-  union { null, string } pageToken = null;
-}
-
-/**
-This is the response from `POST /calls/search` expressed as JSON.
-*/
-record SearchCallsResponse {
-  /** The list of matching calls. */
-  array<org.ga4gh.models.Call> calls = [];
-
-  /**
-  The continuation token, which is used to page through large result sets.
-  Provide this value in a subsequent request to return the next page of
-  results. This field will be empty if there aren't any additional results.
-  */
-  union { null, string } nextPageToken = null;
-}
-
-/**
-Gets a list of `Call` matching the search criteria.
-`POST /calls/search` must accept a JSON version of
-`SearchCallsRequest` as the post body and will return a JSON version of
-`SearchCallsResponse`.
-*/
-SearchCallsResponse searchCalls(
-  /** This request maps to the body of `POST /calls/search` as JSON. */
-  SearchCallsRequest request) throws GAException;
-
-/****************** /allelecalls/search *********************/
-/** This request maps to the body of `POST /allelecalls/search` as JSON. */
-record SearchAlleleCallsRequest {
-
-  /**
-  If nonempty, only return the `AlleleCall`s in these `CallSet`s.
-  */
-  array<string> callSetIds = [];
-
-  /**
-  If nonempty, return only `AlleleCall`s in these `VariantSet`s.
-  */
-  array<string> variantSetIds = [];
-
-  /**
-  If nonempty, return only `AlleleCall`s associated with one of these `Allele`s.
-  */
-  array<string> alleleIds = [];
-
-  /**
-  If nonempty, return only `AlleleCall`s associated with one of these
-  `Variant`s.
-  */
-  array<string> variantIds = [];
-
-  /**
-  Specifies the maximum number of results to return in a single page.
-  If unspecified, a system default will be used.
-  */
-  union { null, int } pageSize = null;
-
-  /**
-  The continuation token, which is used to page through large result sets.
-  To get the next page of results, set this parameter to the value of
-  `nextPageToken` from the previous response.
-  */
-  union { null, string } pageToken = null;
-}
-
-/**
-This is the response from `POST /allelecalls/search` expressed as JSON.
-*/
-record SearchAlleleCallsResponse {
-  /** The list of matching calls. */
-  array<org.ga4gh.models.AlleleCall> alleleCalls = [];
-
-  /**
-  The continuation token, which is used to page through large result sets.
-  Provide this value in a subsequent request to return the next page of
-  results. This field will be empty if there aren't any additional results.
-  */
-  union { null, string } nextPageToken = null;
-}
-
-/**
-Gets a list of `AlleleCall` matching the search criteria.
-`POST /allelecalls/search` must accept a JSON version of
-`SearchAlleleCallsRequest` as the post body and will return a JSON version of
-`SearchAlleleCallsResponse`.
-*/
-SearchAlleleCallsResponse searchAlleleCalls(
-  /** This request maps to the body of `POST /allelecalls/search` as JSON. */
-  SearchAlleleCallsRequest request) throws GAException;
-
 }


### PR DESCRIPTION
This PR changes the semantics of all `SearchObjectRequest`s so they require the ID of a single container object, if applicable. Currently, a number of different conventions exist, making implementation and authorisation difficult. This solves issue #247 and is related to the issues in #248.

Most of the changes are straightforward, and just require the change of a field like (for example) `array<string> dataSetIds = [];` to `string dataSetId;`. There are some problematic cases:

1. `SearchCallsRequest` and `SearchAlleleCallsRequest` both had a large list of options for the containers that they could search over. As an initial strawman I've reduced this to just the parent `CallSet` to be consistent with all the other objects. Reasoning for these:
   1. Since a `CallSet` is part of a `VariantSet`, the variant set is implied by specifying `callSetId`.
   2. Finding  `Calls` for a particular `variantId` is redundant, since `Call`s are embedded in `Variant` objects. If we wish to find the calls for a given variant, we can either find them directly using `SearchVariantsRequest` or make a call to GET `/variants/<id>/`
   3. We are then left with iterating over all calls in a CallSet, which seems like a peculiar thing to do without reference to the containing `Variant` object. However, this might be updated with more meaningful semantics later.
2. `SeachAlleles` is problematic; what is the interplay between the `variantSetId` and the `sequenceId`? If `sequenceId` is required, then why do we need the `variantSetId`? Conceptually, it seems natural that an Allele belongs to a single `VariantSet`.

In terms of backwards compatibility, obviously there are some breaking changes here. These are minor, however, and easily worked around. Server-side, this is a considerable simplification, and so implementation can simply be a special case of the existing semantics. Client-side, users that are using the multi-container search semantics will need to now explicitly iterate over the container IDs that they are interested in.