### PR TITLE
Removed aggregation flags from beacon datasets

### DIFF
--- a/src/main/resources/avro/beacon.avdl
+++ b/src/main/resources/avro/beacon.avdl
@@ -12,7 +12,7 @@ A request for information about a specific site
 record QueryResource {
   /** 
   The reference bases for this variant, starting from `position`, in the genome
-  described by the field `reference`.  (see variants.avdl)
+  described by the field `reference`. (see variants.avdl)
    */
   string referenceBases;
 
@@ -96,12 +96,6 @@ record DataSetResource {
 
   /** Dimensions of the data set. Should be provided if the beacon reports allele frequencies. */
   union{ null, DataSizeResource } size = null;
-
-  /** True if this dataset contains data from 2 or more other datasets. */
-  boolean multiple;
-
-  /** List of names of each of the datasets that comprises this aggregated dataset. Should be provided if `multiple` is true. */
-  array<string> datasets = [];
 
   /** Data use limitations, specified as a set of DataUseResource. */
   array<DataUseResource> data_use = [];


### PR DESCRIPTION
My understanding is that datasets are aggregated by beacons and do not need another level of aggregation on their own. If a dataset consists of of data from other datasets, this fact can be noted in its description, but does not need a specific field. This was discussed and resolved in a thread on the [Beacon 0.2 draft document](https://docs.google.com/document/d/154GBOixuZxpoPykGKcPOyrYUcgEXVe2NvKx61P4Ybn4/edit#heading=h.234otr74rjti), here's a log from that conversation:

- 11:44 AM Jan 26 Douglas Slotta: "aggregates" I'm not sure this is the best name. Perhaps subsets? subDatasets?
- 12:14 PM Jan 26 Maximilian Haeussler: I think this makes it too complicated and I don't understand the meaning of "aggregate".
- 11:34 AM Jan 27 Douglas Slotta: I've changed the fields a bit for clarity. I don't think this is too complicated. It merely allows the beacon provider to predefine any combined datasets. However, for the user, it would work like any other dataset.
- 1:17 PM Jan 29 Miro Cupak: I'm with Max on this - I don't think we need to distinguish aggregation at this level so that we don't add up specifying a beacon of beacons. If anyone wants to provide such datasets, they can still mark them somehow outside the scope of this spec.
- 1:21 PM Jan 29 Miro Cupak: I'd also rather not deal with overlapping datasets at this level - if I aggregate a few datasets and add some extra data on top, do I mark it as an aggregate?
- 12:35 PM Mar 17 Andrew Zimmer: Marked as resolved

