### PR TITLE
First stab at free `Allele`s, with a semantic search for them.

### DIFF
--- a/src/main/resources/avro/references.avdl
+++ b/src/main/resources/avro/references.avdl
@@ -111,8 +111,8 @@ reference assembly, such as `GRCh38`. A `ReferenceSet` defines a common
 coordinate space for comparing reference-aligned experimental data.
 
 `ReferenceSet`s are composeable: a `ReferenceSet` may incorporate all of the
-`Reference`s and `Join`s from one or more other `ReferenceSet`s via the
-`includedReferenceSet`s array.
+`Reference`s and `Join`s from one other `ReferenceSet` via the
+`includedReferenceSetId` field.
 
 In classic mode, this is just a set of sequences.  In graph mode, there
 are both sequences and joins, but we only access the joins via method
@@ -133,22 +133,19 @@ record ReferenceSet {
   union { null, array<string> } referenceIds = null;
 
   /**
-  The IDs of `ReferenceSet`s that are included in this set, allowing extension
-  from a core e.g. provided by GRC or another provider.  In particular this
-  may provide a basis of primary references for a graph mode reference set.
+  The ID of a `ReferenceSet`s that is included in this set, allowing extension
+  from a core e.g. provided by GRC or another provider.  In particular this may
+  provide a basis of primary references for a graph mode reference set.
 
   A `ReferenceSet` is not allowed to include itself, either directly by ID, or
   indirectly or transitively through another `ReferenceSet`.
 
-  `Reference`s and `Join`s from the included `ReferenceSet`s are considered to
-  be part of this one. If multiple included `ReferenceSet`s provide a
-  `Reference` or `Join`, only one copy is taken to exist in this `ReferenceSet`.
-  Since different `Reference`s on a `Sequence` may not overlap, it is illegal to
-  include `ReferenceSet`s which when taken together would create such an
-  overlap, or to have such an overlap between a `Reference` from an included
-  `ReferenceSet` and one that appears directly in this `ReferenceSet`.
+  `Reference`s and `Join`s from the included `ReferenceSet` are considered to be
+  part of this one. Since different `Reference`s on a `Sequence` may not
+  overlap, it is illegal to have such an overlap between a `Reference` from an
+  included `ReferenceSet` and one that appears directly in this `ReferenceSet`.
   */
-  array<string> includedReferenceSets = [];
+  union { null, string } includedReferenceSetId = null;
 
   /**
   Order-independent MD5 checksum which identifies this `ReferenceSet`.

--- a/src/main/resources/avro/variantmethods.avdl
+++ b/src/main/resources/avro/variantmethods.avdl
@@ -163,8 +163,17 @@ org.ga4gh.models.Variant getVariant(
 /******************  /alleles/search  *********************/
 /** This request maps to the body of `POST /alleles/search` as JSON. */
 record SearchAllelesRequest {
-  /** Required. The IDs of the variant sets to search over. */
+  /**
+  If nonempty, look only at `Allele`s used in at least one of the specified
+  `VariantSet`s. `Allele`s that are not used in any `VariantSet`s may only be
+  returned if this is empty.
+  */
   array<string> variantSetIds = [];
+  
+  /**
+  If present, look only at `Allele`s in the specified dataset.
+  */
+  union { null, string } datasetId = null; 
 
   /**
   Required. Only return `Allele`s on the sequence with this ID.
@@ -238,6 +247,75 @@ org.ga4gh.models.Allele getAllele(
   The ID of the `Allele`.
   */
   string id) throws GAException;
+  
+/******************  /alleles/search/path  *********************/
+/** This request maps to the body of `POST /alleles/search/path` as JSON. */
+record SearchAllelesPathRequest {
+  /**
+  If present, look only at `Allele`s in the specified `Dataset`.
+  */
+  union { null, string } datasetId = null; 
+
+  /**
+  If present, look only at `Allele`s used in the specified `VariantSet`.
+  */
+  union { null, string } variantSetId = null; 
+
+  /**
+  Specifies a search algorithm to use, which defines the exact semantics of what
+  it means for an `Allele` to be "relevant" to a `Path`. If the server does not
+  support the sp[ecified algorithm, it will throw an error.
+  */
+  string algorithm;
+
+  /**
+  Specifies a path. Only alleles "relevant" to the specified `Path` under the
+  specified algorithm will be returned.
+  */
+  org.ga4gh.models.Path query;
+
+  /**
+  Specifies the maximum number of results to return in a single page.
+  If unspecified, a system default will be used.
+  */
+  union { null, int } pageSize = null;
+
+  /**
+  The continuation token, which is used to page through large result sets.
+  To get the next page of results, set this parameter to the value of
+  `nextPageToken` from the previous response.
+  */
+  union { null, string } pageToken = null;
+}
+
+/** This is the response from `POST /alleles/search/path` expressed as JSON. */
+record SearchAllelesPathResponse {
+  /**
+  The list of relevant alleles. An `Allele` should be returned if the specified
+  search algorithm deems it relevant to the specified path.
+  */
+  array<org.ga4gh.models.Allele> alleles = [];
+
+  /**
+  The continuation token, which is used to page through large result sets.
+  Provide this value in a subsequent request to return the next page of
+  results. This field will be empty if there aren't any additional results.
+  */
+  union { null, string } nextPageToken = null;
+}
+
+/**
+Gets a list of `Allele`s relevant to a path.
+
+`POST /alleles/search/path` must accept a JSON version of
+`SearchAllelesPathRequest` as the post body and will return a JSON version of
+`SearchAllelesPathResponse`.
+*/
+SearchAllelesPathResponse searchAllelesPath(
+    /**
+    This request maps to the body of `POST /alleles/search/path` as JSON.
+    */
+    SearchAllelesPathRequest request) throws GAException;
 
 /******************  /callsets/search  *********************/
 /** This request maps to the body of `POST /callsets/search` as JSON. */

--- a/src/main/resources/avro/variantmethods.avdl
+++ b/src/main/resources/avro/variantmethods.avdl
@@ -164,16 +164,21 @@ org.ga4gh.models.Variant getVariant(
 /** This request maps to the body of `POST /alleles/search` as JSON. */
 record SearchAllelesRequest {
   /**
-  If nonempty, look only at `Allele`s used in at least one of the specified
-  `VariantSet`s. `Allele`s that are not used in any `VariantSet`s may only be
-  returned if this is empty.
+  If nonempty, look only at `Allele`s used in the specified `VariantSet`. This
+  includes both `Allele`s novel to that `VariantSet` and `Allele`s from the
+  associated `ReferenceSet` with `AlleleCall`s in that `VariantSet`.
+
+  Either this field or referenceSetId must be set.
   */
-  array<string> variantSetIds = [];
-  
+  union { null, string } variantSetId = null;
+
   /**
-  If present, look only at `Allele`s in the specified dataset.
+  If present, look only at `Allele`s in the specified `ReferenceSet`,
+  including those it inherits from included `ReferenceSet`s.
+
+  Either this field or variantSetId must be set.
   */
-  union { null, string } datasetId = null; 
+  union { null, string } referenceSetId = null;
 
   /**
   Required. Only return `Allele`s on the sequence with this ID.
@@ -247,19 +252,23 @@ org.ga4gh.models.Allele getAllele(
   The ID of the `Allele`.
   */
   string id) throws GAException;
-  
+
 /******************  /alleles/search/path  *********************/
 /** This request maps to the body of `POST /alleles/search/path` as JSON. */
 record SearchAllelesPathRequest {
   /**
-  If present, look only at `Allele`s in the specified `Dataset`.
+  If present, look only at `Allele`s in the specified `ReferenceSet`.
+
+  Exactly one of this and `variantSetId` must be non-null.
   */
-  union { null, string } datasetId = null; 
+  union { null, string } referenceSetId = null;
 
   /**
   If present, look only at `Allele`s used in the specified `VariantSet`.
+
+  Exactly one of this and `referenceSetId` must be non-null.
   */
-  union { null, string } variantSetId = null; 
+  union { null, string } variantSetId = null;
 
   /**
   Specifies a search algorithm to use, which defines the exact semantics of what
@@ -269,8 +278,12 @@ record SearchAllelesPathRequest {
   string algorithm;
 
   /**
-  Specifies a path. Only alleles "relevant" to the specified `Path` under the
+  Specifies a `Path`. Only alleles "relevant" to the specified `Path` under the
   specified algorithm will be returned.
+
+  The `Path` must use only `Sequence`s and `Join`s available in the
+  `ReferenceSet` specified by `referenceSetId` or the `VariantSet` specified by
+  `VariantSetId`.
   */
   org.ga4gh.models.Path query;
 

--- a/src/main/resources/avro/variants.avdl
+++ b/src/main/resources/avro/variants.avdl
@@ -370,9 +370,12 @@ it is also common for it to be a mix of `Segment`s on reference and novel
 `Sequence`s, or in general to be any contiguous path through the augmented
 sequence graph.
 
-`Allele`s are persistent named objects, and may exist either in a `ReferenceSet`
-or be novel to a `VariantSet`. Zero or more `Variant`s in a `VariantSet` may use
-a single `Allele`.
+`Allele`s are persistent named objects, and may be associated with any number of
+`VariantSet`s and/or `ReferenceSet`s. Like `Sequence`s and `Join`s, `Allele`s
+are inherited when one `ReferenceSet` includes another. Zero or more `Variant`s
+in a `VariantSet` may use a single `Allele`.
+
+To get the `Allele`s in a `ReferenceSet` or `VariantSet`, use `searchAlleles()`.
 
 Note that `Path`s cannot follow `Join`s not represented in the relevant sequence
 graph. For example, if  an `Allele` in a `VariantSet` describes a novel deletion
@@ -386,24 +389,6 @@ record Allele {
   the entirety of a `Sequence`, this is equal to the ID of that `Sequence`.
   */
   string id;
-
-  /**
-  The ID of the VariantSet that this `Allele` is novel in, if any.
-
-  Either this or `referenceSetId` must be non-null.
-  */
-  union { null, string } variantSetId = null;
-
-  /**
-  The ID of the `ReferenceSet` that contains this `Allele`. Note that the
-  `Allele` is also inherited by all descendants of that `ReferenceSet`.
-
-  Either this or `referenceSetId` must be non-null.
-
-  TODO: Do we need to allow an `Allele` to exist in multiple `ReferenceSet`s
-  without being inherited from their common ancestor?
-  */
-  union { null, string } referenceSetId = null;
 
   /**
   The ordered and oriented `Segment`s of DNA that this `Allele` represents.

--- a/src/main/resources/avro/variants.avdl
+++ b/src/main/resources/avro/variants.avdl
@@ -56,7 +56,13 @@ The variant set is equivalent to a VCF file.
 
 A `VariantSet` can contain novel `Sequence`s, which are used to augment the
 sequence graph of its `ReferenceSet`, creating the augmented sequence graph
-against which `Allele`s are interpreted.
+against which `Allele`s are interpreted. All `Sequence`s and `Join`s used in
+`Allele`s that the `VariantSet` uses are so included, and musty be available
+through the `searchSequences()` and `searchJoins()` methods on the `VariantSet`.
+
+The novel `Sequence`s and `Join`s in a `VariantSet` must constitute a "simple"
+extension of the `VariantSet`'s `ReferenceSet`. That is, no novel `Join` may
+connect to novel `Sequence`s at both ends.
 */
 record VariantSet {
   /** The variant set ID. */
@@ -365,13 +371,13 @@ it is also common for it to be a mix of `Segment`s on reference and novel
 `Sequence`s, or in general to be any contiguous path through the augmented
 sequence graph.
 
-`Allele`s belong to `VariantSet`s. `Allele`s can also be used to represent the
-reference and alternate alleles of `Variant`s.
+`Allele`s are persistent named objects that may be used in multiple
+`VariantSet`s and/or `Variant`s.
 
 Note that `Path`s cannot follow `Join`s not represented in the augmented
-sequence graph. For example, if  an `Allele` that spans a novel deletion is
-required, a new `Join` should exist to describe that deletion, available through
-`searchJoins()`.
+sequence graph. For example, if  an `Allele` in a `VariantSet` describes a novel
+deletion relative to the applicable `ReferenceSet`, the `Join` describing that
+deletion must be available through `searchJoins()` on the `VariantSet`.
 */
 record Allele {
   /**
@@ -379,16 +385,17 @@ record Allele {
   the entirety of a `Sequence`, this is equal to the ID of that `Sequence`.
   */
   string id;
-
-  /** The ID of the variant set this allele belongs to. */
-  string variantSetId;
+  
+  /**
+  The `Dataset` that this `Allele` belongs to.
+  */
+  string datasetId;
 
   /**
   The ordered and oriented `Segment`s of DNA that this `Allele` represents.
-
-  `Segment`s on this `Path` are on either `Reference` `Sequence`s, or
-  `Sequence`s associated with this `VariantSet. Both types of `Sequence`s are
-  available through the `searchSequences()` and `getSequence()` API calls.
+  Adjacent `Segment`s must be connected by `Join`s that either occur in the
+  `ReferenceSet` associated with a `VariantSet` using this `Allele`, or are
+  available from `searchJoins()` on that `VariantSet`.
   */
   Path path;
 }

--- a/src/main/resources/avro/variants.avdl
+++ b/src/main/resources/avro/variants.avdl
@@ -54,11 +54,10 @@ record VariantSetMetadata {
 `VariantSet` belongs to a `Dataset`.
 The variant set is equivalent to a VCF file.
 
-A `VariantSet` can contain novel `Sequence`s, which are used to augment the
-sequence graph of its `ReferenceSet`, creating the augmented sequence graph
-against which `Allele`s are interpreted. All `Sequence`s and `Join`s used in
-`Allele`s that the `VariantSet` uses are so included, and musty be available
-through the `searchSequences()` and `searchJoins()` methods on the `VariantSet`.
+A `VariantSet` can contain novel `Sequence`s, and `Join`s, which are used to
+augment the sequence graph of its `ReferenceSet`, creating an augmented sequence
+graph. A `VariantSet` can also contain novel `Allele`s that are interpreted
+against this augmented sequence graph.
 
 The novel `Sequence`s and `Join`s in a `VariantSet` must constitute a "simple"
 extension of the `VariantSet`'s `ReferenceSet`. That is, no novel `Join` may
@@ -371,13 +370,15 @@ it is also common for it to be a mix of `Segment`s on reference and novel
 `Sequence`s, or in general to be any contiguous path through the augmented
 sequence graph.
 
-`Allele`s are persistent named objects that may be used in multiple
-`VariantSet`s and/or `Variant`s.
+`Allele`s are persistent named objects, and may exist either in a `ReferenceSet`
+or be novel to a `VariantSet`. Zero or more `Variant`s in a `VariantSet` may use
+a single `Allele`.
 
-Note that `Path`s cannot follow `Join`s not represented in the augmented
-sequence graph. For example, if  an `Allele` in a `VariantSet` describes a novel
-deletion relative to the applicable `ReferenceSet`, the `Join` describing that
-deletion must be available through `searchJoins()` on the `VariantSet`.
+Note that `Path`s cannot follow `Join`s not represented in the relevant sequence
+graph. For example, if  an `Allele` in a `VariantSet` describes a novel deletion
+relative to the applicable `ReferenceSet`, the `Join` describing that deletion
+must be a novel `Join` in that `VariantSet`, and thus available through
+`searchJoins()` on the `VariantSet`.
 */
 record Allele {
   /**
@@ -385,17 +386,34 @@ record Allele {
   the entirety of a `Sequence`, this is equal to the ID of that `Sequence`.
   */
   string id;
-  
+
   /**
-  The `Dataset` that this `Allele` belongs to.
+  The ID of the VariantSet that this `Allele` is novel in, if any.
+
+  Either this or `referenceSetId` must be non-null.
   */
-  string datasetId;
+  union { null, string } variantSetId = null;
+
+  /**
+  The ID of the `ReferenceSet` that contains this `Allele`. Note that the
+  `Allele` is also inherited by all descendants of that `ReferenceSet`.
+
+  Either this or `referenceSetId` must be non-null.
+
+  TODO: Do we need to allow an `Allele` to exist in multiple `ReferenceSet`s
+  without being inherited from their common ancestor?
+  */
+  union { null, string } referenceSetId = null;
 
   /**
   The ordered and oriented `Segment`s of DNA that this `Allele` represents.
   Adjacent `Segment`s must be connected by `Join`s that either occur in the
   `ReferenceSet` associated with a `VariantSet` using this `Allele`, or are
   available from `searchJoins()` on that `VariantSet`.
+
+  `Segment`s on this `Path` are on either `ReferenceSet` `Sequence`s, or
+  `Sequence`s associated with this `VariantSet. Both types of `Sequence`s are
+  available through the `searchSequences()` and `getSequence()` API calls.
   */
   Path path;
 }


### PR DESCRIPTION
These ideas probably won't be anywhere near ready until #253 and #269 are in. But I was asked by @benedictpaten to spec out how `Allele`s might work if they weren't restricted to a single `VariantSet`. What do people think of that idea?

Changes:

`Allele`s now exist outside of, and can be shared between,
`VariantSet`s. The parent object of an `Allele` is a `Dataset`.

Adding a `searchAllelesPath()` method that can use any of a number of
"algorithms" to get `Allele`s that are "relevant" to a `Path`, for some
algorithm-defined notion of relevance.

Also specifying that the `Allele`s used by a `VariantSet` may only use a
"simple" extension of the `Sequence`s and `Join`s in the relevant
`ReferenceSet`. That is, no novel `Join` may have both ends in novel
`Sequence`s.