### PR TITLE
Removed outdated definition of Experiment from reads.avdl

### DIFF
--- a/src/main/resources/avro/metadata.avdl
+++ b/src/main/resources/avro/metadata.avdl
@@ -314,7 +314,7 @@ record Analysis {
   union { null, string } type = null;
 
   /** The software run to generate this analysis. */
-  array<string> software = null;
+  array<string> software = [];
 
   /**
   A map of additional analysis information.

--- a/src/main/resources/avro/reads.avdl
+++ b/src/main/resources/avro/reads.avdl
@@ -35,6 +35,7 @@ ReadGroupSet >--< ReadGroup --< fragment --< read --< alignment --< linear/graph
 protocol Reads {
 
 import idl "common.avdl";
+import idl "metadata.avdl";
 
 record Program {
   /** The command line used to run this program. */
@@ -59,23 +60,6 @@ record Dataset {
 
   /** The dataset description. */
   union { null, string } description = null;
-}
-
-record Experiment {
-  /** The library used as part of this experiment. */
-  union { null, string } libraryId = null;
-
-  /** The platform unit used as part of this experiment. */
-  union { null, string } platformUnit = null;
-
-  /** The sequencing center used as part of this experiment. */
-  union { null, string } sequencingCenter;
-
-  /**
-  The instrument model used as part of this experiment.
-  This maps to sequencing technology in BAM.
-  */
-  union { null, string } instrumentModel;
 }
 
 record ReadStats {


### PR DESCRIPTION
`reads.avdl` contained a redundant and outdated copy of the `Experiment` record (now contained in `metadata.avdl`, that was causing the server schema tests to fail on post-v0.5.1 schema definitions.