### PR TITLE
Better CI for the schemas repo

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+*.py[cod]
 target
 *~
 #*

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,1 +1,12 @@
-language: java
+language: python
+python:
+  - "2.7"
+
+install:
+    - pip install -r requirements.txt
+
+script:
+    - flake8 scripts tests
+    - nosetests tests
+    - mvn install -DskipTests=true -Dmaven.javadoc.skip=true -B -V
+    - mvn test -B

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,5 @@
+PyYAML
+flake8
+humanize
+nose
+requests

--- a/scripts/run_tests.py
+++ b/scripts/run_tests.py
@@ -1,0 +1,66 @@
+"""
+Script to imitate a Travis CI run
+"""
+
+from __future__ import division
+from __future__ import print_function
+from __future__ import unicode_literals
+
+import glob
+import shlex
+import subprocess
+
+import yaml
+
+import utils
+
+
+class TravisSimulator(object):
+
+    logStrPrefix = '***'
+
+    yamlFileLocation = '.travis.yml'
+
+    def parseTestCommands(self):
+        yamlFile = file(self.yamlFileLocation)
+        yamlData = yaml.load(yamlFile)
+        return yamlData['script']
+
+    def expandCommand(self, command):
+        # subprocess.check_call doesn't expand globs by default, unless
+        # shell=True is passed, which is a security hazzard.
+        # This gets around that limitation by implementing some shell features
+        # which should be enough for our purposes.  See:
+        # https://docs.python.org/2/library/subprocess.html
+        # #frequently-used-arguments
+        if '*' not in command:
+            return command
+        splits = shlex.split(command)
+        expandedSplits = []
+        for split in splits:
+            if '*' in split:
+                files = glob.glob(split)
+                expandedSplits.extend(files)
+            else:
+                expandedSplits.append(split)
+        return ' '.join(expandedSplits)
+
+    def runTests(self):
+        testCommands = self.parseTestCommands()
+        for command in testCommands:
+            expandedCommand = self.expandCommand(command)
+            self.log('Running: "{0}"'.format(expandedCommand))
+            try:
+                utils.runCommand(expandedCommand)
+            except subprocess.CalledProcessError:
+                self.log('ERROR')
+                return
+        self.log('SUCCESS')
+
+    def log(self, logStr):
+        utils.log("{0} {1}".format(self.logStrPrefix, logStr))
+
+
+if __name__ == '__main__':
+    travisSimulator = TravisSimulator()
+    travisSimulator.runTests()

--- a/scripts/utils.py
+++ b/scripts/utils.py
@@ -1,0 +1,132 @@
+"""
+Utilities for scripts
+"""
+from __future__ import division
+from __future__ import print_function
+from __future__ import unicode_literals
+
+import functools
+import os
+import shlex
+import subprocess
+import sys
+import time
+
+import humanize
+import requests
+import yaml
+
+
+def log(message):
+    print(message)
+
+
+class Timed(object):
+    """
+    Decorator that times a method, reporting runtime at finish
+    """
+    def __call__(self, func):
+        @functools.wraps(func)
+        def wrapper(*args, **kwargs):
+            self.start = time.time()
+            result = func(*args, **kwargs)
+            self.end = time.time()
+            self._report()
+            return result
+        return wrapper
+
+    def _report(self):
+        delta = self.end - self.start
+        timeString = humanize.time.naturaldelta(delta)
+        log("Finished in {} ({} seconds)".format(timeString, delta))
+
+
+class FileDownloader(object):
+    """
+    Provides a wget-like file download and terminal display
+    """
+    defaultChunkSize = 1048576  # 1MB
+    defaultStream = sys.stdout
+
+    def __init__(self, url, path, chunkSize=defaultChunkSize,
+                 stream=defaultStream):
+        self.url = url
+        self.path = path
+        self.basename = os.path.basename(url)
+        self.basenameLength = len(self.basename)
+        self.chunkSize = chunkSize
+        self.stream = stream
+        self.bytesWritten = 0
+        self.displayIndex = 0
+        self.displayWindowSize = 20
+
+    def download(self):
+        self.stream.write("Downloading '{}' to '{}'\n".format(
+            self.url, self.path))
+        response = requests.get(self.url, stream=True)
+        response.raise_for_status()
+        self.contentLength = int(response.headers['content-length'])
+        with open(self.path, 'wb') as outputFile:
+            for chunk in response.iter_content(chunk_size=self.chunkSize):
+                self.bytesWritten += self.chunkSize
+                self._updateDisplay()
+                outputFile.write(chunk)
+        self.stream.write("\n")
+        self.stream.flush()
+
+    def _getFileNameDisplayString(self):
+        if self.basenameLength <= self.displayWindowSize:
+            return self.basename
+        else:
+            return self.basename  # TODO scrolling window here
+
+    def _updateDisplay(self):
+        fileName = self._getFileNameDisplayString()
+
+        # TODO contentLength seems to slightly under-report how many bytes
+        # we have to download... hence the min functions
+        percentage = min(self.bytesWritten / self.contentLength, 1)
+        numerator = humanize.filesize.naturalsize(
+            min(self.bytesWritten, self.contentLength))
+        denominator = humanize.filesize.naturalsize(
+            self.contentLength)
+
+        displayString = "{}   {:<6.2%} ({:>9} / {:<9})\r"
+        self.stream.write(displayString.format(
+            fileName, percentage, numerator, denominator))
+        self.stream.flush()
+
+
+def runCommandSplits(splits, silent=False):
+    """
+    Run a shell command given the command's parsed command line
+    """
+    if silent:
+        with open(os.devnull, 'w') as devnull:
+            subprocess.check_call(splits, stdout=devnull, stderr=devnull)
+    else:
+        subprocess.check_call(splits)
+
+
+def runCommand(command, silent=False):
+    """
+    Run a shell command
+    """
+    splits = shlex.split(command)
+    runCommandSplits(splits, silent=silent)
+
+
+def getAuthValues(filePath='scripts/auth.yml'):
+    """
+    Return the script authentication file as a dictionary
+    """
+    return getYamlDocument(filePath)
+
+
+def getYamlDocument(filePath):
+    """
+    Return a yaml file's contents as a dictionary
+    """
+    with open(filePath) as stream:
+        doc = yaml.load(stream)
+        return doc

--- a/tests/test_test.py
+++ b/tests/test_test.py
@@ -1,0 +1,14 @@
+"""
+A placeholder for future tests
+"""
+from __future__ import division
+from __future__ import print_function
+from __future__ import unicode_literals
+
+import unittest
+
+
+class TestTest(unittest.TestCase):
+
+    def testDummy(self):
+        self.assertTrue(True)


### PR DESCRIPTION
The point of this change is to have more stringent CI on schema repo checkins so we don't encounter problems downstream parsing and using the schemas in the server repo.

This will be accomplished by copying -- in a modified form -- some of the code that we have developed in the server repo for manipulating avro schemas into the schemas repo.  We can add additional checks with python scripts as we uncover issues.

This change is discussed in the server repo here: https://github.com/ga4gh/server/issues/366