### PR TITLE
Modify sequences/{id} endpoint semantics for serving out sequence bases.

### DIFF
--- a/src/main/resources/avro/referencemethods.avdl
+++ b/src/main/resources/avro/referencemethods.avdl
@@ -326,41 +326,19 @@ SearchSequencesResponse searchSequences(
   */
   SearchSequencesRequest request) throws GAException;
 
-/****************  /sequences/{id}  *******************/
+/****************  /sequences/{id}/bases  *******************/
 /**
-The query parameters for a request to `GET /sequence/{id}`, for
+The query parameters for a request to `GET /sequences/{id}/bases`, for
 example:
 
-`GET /sequence/c95d4520-8c63-45f1-924d-6a9604a919fb?start=100&end=200`
+`GET /sequences/c95d4520-8c63-45f1-924d-6a9604a919fb/bases?start=100&end=200`
 */
-record GetSequenceBasesRequest {
-  /**
-  The start position (0-based) of this query. Defaults to 0.
-  Genomic positions are non-negative integers less than segment length.
-  Requests spanning the join of circular genomes are represented as
-  two requests one on each side of the join (position 0).
-  */
-  long start = 0;
 
-  /**
-  The end position (0-based, exclusive) of this query. Defaults
-  to the length of this `Segment`.
-  */
-  union { null, long } end = null;
-
-  /**
-  The continuation token, which is used to page through large result sets.
-  To get the next page of results, set this parameter to the value of
-  `nextPageToken` from the previous response.
-  */
-  union { null, string } pageToken = null;
-}
-
-/** The response from `GET /sequence/{id}` expressed as JSON. */
+/** The response from `GET /sequences/{id}/bases` expressed as JSON. */
 record GetSequenceBasesResponse {
   /**
   The offset position (0-based) of the returned string in the sequence. This
-  value will differ for each page in a paginated request.
+  value should match the start request parameter, or be 0.
    */
   long offset = 0;
 
@@ -369,26 +347,20 @@ record GetSequenceBasesResponse {
   codes; this string matches the regexp `[ACGTMRWSYKVHDBN]*`.
   */
   string sequence;
-
-  /**
-  The continuation token, which is used to page through large result sets.
-  Provide this value in a subsequent request to return the next page of
-  results. This field will be empty if there aren't any additional results.
-  */
-  union { null, string } nextPageToken = null;
 }
 
 /**
-Lists bases by sequence ID and optional range. `GET /sequence/{id}` will return
-a JSON version of `GetSequenceBasesResponse`. Works for sequences with
-associated `Reference`s, as well as novel sequences that come with
+Lists bases by sequence ID and optional range. `GET /sequences/{id}/bases`
+will return a JSON version of `GetSequenceBasesResponse`. Works for sequences
+with associated `Reference`s, as well as novel sequences that come with
 `VariantSet`s.
 */
 GetSequenceBasesResponse getSequenceBases(
     /** The ID of the sequence. */
     string id,
     /** Additional request parameters to restrict the query. */
-    GetSequenceBasesRequest request) throws GAException;
+    union {null, long} start = null,
+    union {null, long} end) throws GAException;
 
 /****************  /joins/search  *******************/
 /**


### PR DESCRIPTION
The `sequences/{id}` endpoint was modified as follows:

- changed endpoint name to `sequences/{id}/bases` the better to express its semantics
- request object was removed (since this is a `GET` method)
- method definition changed to reflect passing `start`, `end` parameters explicitly instead of via request object.
- `nextPageToken` removed from response object, as client knows length of sequence a priori, can request range explicitly.