### PR TITLE
Fail CI if avro-tools issues warnings

### DIFF
--- a/src/main/resources/avro/metadata.avdl
+++ b/src/main/resources/avro/metadata.avdl
@@ -32,13 +32,13 @@ record Individual {
   TODO: The format definition is temporary and will be updated to 
   the upcoming AVRO time format (timestamp-millis) when this is supported.
   */
-  string recordCreateTime = null;
+  string recordCreateTime;
 
   /**
   The time at which this record was last updated.
   Format: ISO 8601, YYYY-MM-DDTHH:MM:SS.SSS (e.g. 2015-02-10T00:03:42.123Z)
   */
-  string recordUpdateTime = null;
+  string recordUpdateTime;
 
   /**
   The species of this individual. Using
@@ -119,13 +119,13 @@ record Sample {
   The time at which this record was created. 
   Format: ISO 8601, YYYY-MM-DDTHH:MM:SS.SSS (e.g. 2015-02-10T00:03:42.123Z)
   */
-  string  recordCreateTime = null;
+  string recordCreateTime;
 
   /**
   The time at which this record was last updated.
   Format: ISO 8601, YYYY-MM-DDTHH:MM:SS.SSS (e.g. 2015-02-10T00:03:42.123Z)
   */
-  string recordUpdateTime = null;
+  string recordUpdateTime;
 
   /**
   The time at which this sample was taken from the individual.
@@ -193,13 +193,13 @@ record Experiment {
   The time at which this record was created. 
   Format: ISO 8601, YYYY-MM-DDTHH:MM:SS.SSS (e.g. 2015-02-10T00:03:42.123Z)
   */
-  string recordCreateTime = null;
+  string recordCreateTime;
 
   /**
   The time at which this record was last updated.
   Format: ISO 8601, YYYY-MM-DDTHH:MM:SS.SSS (e.g. 2015-02-10T00:03:42.123Z)
   */
-  string recordUpdateTime = null;
+  string recordUpdateTime;
 
   /**
   The time at which this experiment was performed.
@@ -276,13 +276,13 @@ record IndividualGroup {
   The time at which this record was created. 
   Format: ISO 8601, YYYY-MM-DDTHH:MM:SS.SSS (e.g. 2015-02-10T00:03:42.123Z)
   */
-  string recordCreateTime = null;
+  string recordCreateTime;
 
   /**
   The time at which this record was last updated.
   Format: ISO 8601, YYYY-MM-DDTHH:MM:SS.SSS (e.g. 2015-02-10T00:03:42.123Z)
   */
-  string recordUpdateTime = null;
+  string recordUpdateTime;
 
   /** The type of individual group. */
   union { null, string } type = null;
@@ -312,13 +312,13 @@ record Analysis {
   The time at which this record was created. 
   Format: ISO 8601, YYYY-MM-DDTHH:MM:SS.SSS (e.g. 2015-02-10T00:03:42.123Z)
   */
-  string recordCreateTime = null;
+  union { null, string } recordCreateTime = null;
 
   /**
   The time at which this record was last updated.
   Format: ISO 8601, YYYY-MM-DDTHH:MM:SS.SSS (e.g. 2015-02-10T00:03:42.123Z)
   */
-  string recordUpdateTime = null;
+  string recordUpdateTime;
 
   /** The type of analysis. */
   union { null, string } type = null;

--- a/tests/compile_schemas.py
+++ b/tests/compile_schemas.py
@@ -54,7 +54,6 @@ class SchemaProcessor(object):
     """
     def __init__(self, args):
         self.version = args.version
-        self.verbosity = args.verbose
         self.tmpDir = tempfile.mkdtemp(prefix="ga4gh_")
         self.avroJarPath = args.avro_tools_jar
         # Note! The tarball does not contain the leading v
@@ -71,8 +70,6 @@ class SchemaProcessor(object):
         self._initPostSignatures()
 
     def cleanup(self):
-        if self.verbosity > 1:
-            utils.log("Cleaning up tmp dir {}".format(self.tmpDir))
         shutil.rmtree(self.tmpDir)
 
     def getClasses(self):
@@ -94,14 +91,12 @@ class SchemaProcessor(object):
 
     def _convertAvro(self, avdlFile):
         args = ["java", "-jar", self.avroJar, "idl2schemata", avdlFile]
-        if self.verbosity > 0:
-            utils.log("converting {}".format(avdlFile))
-        if self.verbosity > 1:
-            utils.log("running: {}".format(" ".join(args)))
-        if self.verbosity > 1:
-            utils.runCommandSplits(args)
-        else:
-            utils.runCommandSplits(args, silent=True)
+        stdoutLines, stderrLines = utils.runCommandSplitsOutput(args)
+        printableArgs = "'{}'".format(" ".join(args))
+        utils.ensureNoWarnings(
+            stdoutLines, "stdout of {}".format(printableArgs))
+        utils.ensureNoWarnings(
+            stderrLines, "stderr of {}".format(printableArgs))
 
     def _getSchemaFromLocal(self):
         if not os.path.exists(self.avdlDirectory):

--- a/tests/test_maven.py
+++ b/tests/test_maven.py
@@ -12,14 +12,6 @@ import unittest
 import utils
 
 
-def grep(lines, string_):
-    matchingLines = []
-    for line in lines:
-        if string_ in line:
-            matchingLines.append(line[:-1])
-    return matchingLines
-
-
 class TestMaven(unittest.TestCase):
     """
     Uses maven to run tests
@@ -36,9 +28,4 @@ class TestMaven(unittest.TestCase):
         utils.log("Running '{}'".format(cmd))
         splits = shlex.split(cmd)
         output = subprocess.check_output(splits).split('\n')
-        pattern = "[WARNING]"
-        lines = grep(output, pattern)
-        if len(lines) != 0:
-            for line in lines:
-                utils.log(line)
-            self.fail("Command '{}' issued warning(s)".format(cmd))
+        utils.ensureNoWarnings(output, cmd)

--- a/tests/test_protocol.py
+++ b/tests/test_protocol.py
@@ -40,7 +40,6 @@ class TestValidateSchemas(unittest.TestCase):
         args = FakeArgs()
         args.version = "test"
         args.avro_tools_jar = None
-        args.verbose = 2
         return args
 
     def testSchemaProperties(self):


### PR DESCRIPTION
- change metadata time types from string to union { null, string } to
    eliminate warnings
- also remove compile_schemas verbosity flag, plus some other
    refactoring

Issue #306