### PR TITLE
Fragment Object (WIP)

### DIFF
--- a/src/main/resources/avro/readmethods.avdl
+++ b/src/main/resources/avro/readmethods.avdl
@@ -43,6 +43,12 @@ record SearchReadsRequest {
   union { null, long } end = null;
 
   /**
+  If nonempty, restrict this query to 'readAlignment's within the given
+  `Fragment`s. */
+  */
+  array<string> fragmentId = [];
+
+  /**
   Specifies the maximum number of results to return in a single page.
   If unspecified, a system default will be used.
   */

--- a/src/main/resources/avro/readmethods.avdl
+++ b/src/main/resources/avro/readmethods.avdl
@@ -43,7 +43,7 @@ record SearchReadsRequest {
   union { null, long } end = null;
 
   /**
-  If nonempty, restrict this query to 'readAlignment's within the given
+  If nonempty, restrict this query to `readAlignment`s within the given
   `Fragment`s. */
   */
   array<string> fragmentId = [];

--- a/src/main/resources/avro/readmethods.avdl
+++ b/src/main/resources/avro/readmethods.avdl
@@ -14,7 +14,10 @@ to `ReferenceSet`s containing that same `Reference`. If no reference is
 specified, all `ReadGroup`s must be aligned to the same `ReferenceSet`.
 */
 record SearchReadsRequest {
-  /** If nonempty, restrict this query to reads within the given readgroups. */
+  /**
+  If nonempty, restrict this query to `ReadAlignment`s within the given
+  `ReadGroup`s.
+  */
   array<string> readGroupIds = [];
 
   /**
@@ -56,7 +59,7 @@ record SearchReadsRequest {
 /** This is the response from `POST /reads/search` expressed as JSON. */
 record SearchReadsResponse {
   /**
-  The list of matching alignment records, sorted by position.
+  The list of matching `ReadAlignment` records, sorted by position.
   Unmapped reads, which have no position, are returned last.
   */
   array<org.ga4gh.models.ReadAlignment> alignments = [];
@@ -70,7 +73,7 @@ record SearchReadsResponse {
 }
 
 /**
-Gets a list of `ReadAlignment` matching the search criteria.
+Gets a list of `ReadAlignment`s matching the search criteria.
 
 `POST /reads/search` must accept a JSON version of `SearchReadsRequest` as
 the post body and will return a JSON version of `SearchReadsResponse`.

--- a/src/main/resources/avro/reads.avdl
+++ b/src/main/resources/avro/reads.avdl
@@ -3,12 +3,12 @@
 /**
 This file defines the objects used to represent a hierarchy of reads and alignments:
 
-ReadGroupSet >--< ReadGroup --< fragment --< read --< alignment --< linear/graph alignment
+ReadGroupSet >--< ReadGroup --< Fragment --< read --< alignment --< linear/graph alignment
 
 * A ReadGroupSet is a logical collection of ReadGroup's.
 * A ReadGroup is all the data that's processed the same way by the sequencer.
  There are typically 1-10 ReadGroup's in a ReadGroupSet.
-* A *fragment* is a single stretch of a DNA molecule. There are typically
+* A Fragment is a single stretch of a DNA molecule. There are typically
  millions of fragments in a ReadGroup. A fragment has a name (QNAME in BAM
  spec), a length (TLEN in BAM spec), and an array of reads.
 * A *read* is a contiguous sequence of bases. There are typically only one or
@@ -29,7 +29,7 @@ ReadGroupSet >--< ReadGroup --< fragment --< read --< alignment --< linear/graph
  of a chimeric alignment.
 * A ReadAlignment object is a flattened representation of the bottom layers
  of this hierarchy. There's exactly one such object per *linear alignment* or
- *graph alignment*. The object contains alignment info, plus fragment and read
+ *graph alignment*. The object contains alignment info and read
  info for easy access.
 */
 protocol Reads {
@@ -208,6 +208,27 @@ record Fragment {
   /** The fragment ID. */
   string id;
 
+  /** The fragment name. Equivalent to QNAME (query template name) in SAM.*/
+  string fragmentName;
+
+  /**
+  The orientation and the distance between reads from the fragment are
+  consistent with the sequencing protocol (equivalent to SAM flag 0x2)
+  */
+  union { null, boolean } properPlacement = null;
+
+  /** The fragment is a PCR or optical duplicate (SAM flag 0x400) */
+  union { null, boolean } duplicateFragment = null;
+
+  /** The number of reads in the fragment (extension to SAM flag 0x1) */
+  union { null, int } numberReads = null;
+
+  /** The observed length of the fragment, equivalent to TLEN in SAM. */
+  union { null, int } fragmentLength = null;
+
+  /** The `ReadAlignment`s in the fragment
+  array<ReadAlignment> readAlignments = [];
+
 }
 
 /**
@@ -231,28 +252,10 @@ record ReadAlignment {
   */
   string readGroupId;
 
-  // fragment attributes
-  
+  // We preserve this so that a list of reads with data equivalent to a bam
+  // file may be generated in linear time
   /** The fragment ID that this ReadAlignment belongs to. */
   string fragmentId;
-
-  /** The fragment name. Equivalent to QNAME (query template name) in SAM.*/
-  string fragmentName;
-
-  /**
-  The orientation and the distance between reads from the fragment are
-  consistent with the sequencing protocol (equivalent to SAM flag 0x2)
-  */
-  union { null, boolean } properPlacement = null;
-
-  /** The fragment is a PCR or optical duplicate (SAM flag 0x400) */
-  union { null, boolean } duplicateFragment = null;
-
-  /** The number of reads in the fragment (extension to SAM flag 0x1) */
-  union { null, int } numberReads = null;
-
-  /** The observed length of the fragment, equivalent to TLEN in SAM. */
-  union { null, int } fragmentLength = null;
 
   // read attributes
 


### PR DESCRIPTION
I'll leave this here as a starting point for discussion. This reopens the can of worms from #212.
By keeping the fragmentId in the ReadAlignment, construction of a bam equivalent object should remain extremely simple.

