### PR TITLE
Create Dataset in metadata.avdl

### DIFF
--- a/src/main/resources/avro/metadata.avdl
+++ b/src/main/resources/avro/metadata.avdl
@@ -264,6 +264,7 @@ Represents a group of data objects of one or more types (e.g. all Individuals, S
 associated with a clinical study; or e.g. a trio in genetic diagnostics.).
 This concept may be expanded in the future (ontology for describing the type of dataset ...).
 This record replaces and extends the previous "IndividualGroup" record type.
+TODO: Determination of scope, structure, specific attributes.
 */
 record Dataset {
   /** The dataset UUID. This is globally unique. */
@@ -288,29 +289,12 @@ record Dataset {
   string recordUpdateTime;
 
   /**
-  The type of dataset. Examples could be "trio", "metaanalysis", "GWAS"...
-  */
-  union { null, string } datasetType = null;
-
-  /**
-  The uuid's of included records.
-  */
-  array<string> recordsIncluded = [];
-
-  /**
-  The type of included records (ga4gh.Sample, ga4gh.reads ...).
-  TODO: Define necessity of this since types can be derived from the 
-  referenced records.
-  TODO: Define if records are limited to a single type or heterogeneous.
-  */
-  union { null, string } recordsType = null;
-
-  /**
-  A map of additional individual group information.
+  A map of additional information.
   */
   map<array<string>> info = {};
   
 }
+
 /**
 An analysis contains an interpretation of one or several experiments.
 (e.g. SNVs, copy number variations, methylation status) together with

--- a/src/main/resources/avro/metadata.avdl
+++ b/src/main/resources/avro/metadata.avdl
@@ -260,16 +260,19 @@ record Experiment {
 }
 
 /**
-Represents a group of individuals. (e.g. a trio)
+Represents a group of data objects of one or more types (e.g. all Individuals, Samples, Experiments 
+associated with a clinical study; or e.g. a trio in genetic diagnostics.).
+This concept may be expanded in the future (ontology for describing the type of dataset ...).
+This record replaces and extends the previous "IndividualGroup" record type.
 */
-record IndividualGroup {
-  /** The individual group UUID. This is globally unique. */
+record Dataset {
+  /** The dataset UUID. This is globally unique. */
   string id;
 
-  /** The name of the individual group. */
+  /** The name of the dataset. */
   union { null, string } name = null;
 
-  /** A description of the individual group. */
+  /** A description of the dataset. */
   union { null, string } description = null;
 
   /**
@@ -284,15 +287,30 @@ record IndividualGroup {
   */
   string recordUpdateTime;
 
-  /** The type of individual group. */
-  union { null, string } type = null;
+  /**
+  The type of dataset. Examples could be "trio", "metaanalysis", "GWAS"...
+  */
+  union { null, string } datasetType = null;
+
+  /**
+  The uuid's of included records.
+  */
+  array<string> recordsIncluded = [];
+
+  /**
+  The type of included records (ga4gh.Sample, ga4gh.reads ...).
+  TODO: Define necessity of this since types can be derived from the 
+  referenced records.
+  TODO: Define if records are limited to a single type or heterogeneous.
+  */
+  union { null, string } recordsType = null;
 
   /**
   A map of additional individual group information.
   */
   map<array<string>> info = {};
+  
 }
-
 /**
 An analysis contains an interpretation of one or several experiments.
 (e.g. SNVs, copy number variations, methylation status) together with

--- a/src/main/resources/avro/metadata.avdl
+++ b/src/main/resources/avro/metadata.avdl
@@ -260,20 +260,16 @@ record Experiment {
 }
 
 /**
-Represents a group of data objects of one or more types (e.g. all Individuals, Samples, Experiments 
-associated with a clinical study; or e.g. a trio in genetic diagnostics.).
-This concept may be expanded in the future (ontology for describing the type of dataset ...).
-This record replaces and extends the previous "IndividualGroup" record type.
-TODO: Determination of scope, structure, specific attributes.
+Represents a group of individuals. (e.g. a trio)
 */
-record Dataset {
-  /** The dataset UUID. This is globally unique. */
+record IndividualGroup {
+  /** The individual group UUID. This is globally unique. */
   string id;
 
-  /** The name of the dataset. */
+  /** The name of the individual group. */
   union { null, string } name = null;
 
-  /** A description of the dataset. */
+  /** A description of the individual group. */
   union { null, string } description = null;
 
   /**
@@ -288,11 +284,31 @@ record Dataset {
   */
   string recordUpdateTime;
 
+  /** The type of individual group. */
+  union { null, string } type = null;
+
   /**
-  A map of additional information.
+  A map of additional individual group information.
   */
   map<array<string>> info = {};
-  
+}
+
+/**
+Represents a group of contextually related data objects of (e.g. all Individuals, Samples, 
+Experiments associated with a particular feature; or e.g. a trio in genetic diagnostics.).
+This concept may be expanded in the future (ontology for describing the type of dataset ...).
+TODO: Determination of scope, structure, specific attributes, e.g. limiting to single 
+record type - see http://purl.obolibrary.org/obo/IAO_0000100 - and providing alternative mechanism 
+for heterogeneous data with external contextualization, e.g. all records of different 
+types associated with a clinical study.
+*/
+record Dataset {
+  /** The dataset UUID. This is globally unique. */
+  string id;
+
+  /** A description of the dataset. */
+  union { null, string } description = null;
+
 }
 
 /**

--- a/src/main/resources/avro/reads.avdl
+++ b/src/main/resources/avro/reads.avdl
@@ -54,14 +54,6 @@ record Program {
   union { null, string } version = null;
 }
 
-record Dataset {
-  /** The dataset ID. */
-  string id;
-
-  /** The dataset description. */
-  union { null, string } description = null;
-}
-
 record ReadStats {
   /** The number of aligned reads. */
   union { null, long } alignedReadCount = null;


### PR DESCRIPTION
This PR introduces  ```Dataset``` record type (at the expense of the previous limited ```IndividualGroup```). Please see #248 for some background on this.
```Dataset``` is seen with inherent *evolvability*. There was consensus among the metadata task team that the best way would be to put this forward in a skeleton format, with supposed future feature refinement.