### PR TITLE
Moving the FeaturePhenotypeAssociation class to a more generic PhenotypeAssociation

### DIFF
--- a/src/main/resources/avro/genotypephenotype.avdl
+++ b/src/main/resources/avro/genotypephenotype.avdl
@@ -129,22 +129,42 @@ The instance of association allows us to link a feature to a phenotype,
 multiple times, each bearing potentially different levels of confidence,
 such as resulting from alternative experiments and analysis.
 */
-record FeaturePhenotypeAssociation {
+record PhenotypeAssociation {
   string id;
 
   /**
-    The set of features of the organism that bears the phenotype.
-    This could be as complete as a full complement of variants,
-    or as minimal as the confirmed variants that are known causation
-    for the annotated phenotype.  
-    Examples of features could be variations at the nucleotide level, 
-    large rearrangements at the chromosome level, or relevant epigenetic
-    markers.  Relevant genomic feature types are suggested to be 
-    those typed in the Sequence Ontology (SO).
-
-    The feature set can have only one item, and must not be null.
+    Define the association type.
   */
-  array<Feature> features;
+  org.ga4gh.models.OntologyTerm associationType;
+
+  /**
+    The elements or concepts that are linked to this phenotype.
+    These may be a genomic features, Individuals, and Samples.
+
+    In the case the Features:
+        The set of features of the organism that bears the phenotype.
+        This could be as complete as a full complement of variants,
+        or as minimal as the confirmed variants that are known causation
+        for the annotated phenotype.
+        Examples of features could be variations at the nucleotide level,
+        large rearrangements at the chromosome level, or relevant epigenetic
+        markers.  Relevant genomic feature types are suggested to be
+        those typed in the Sequence Ontology (SO).
+
+        The feature set can have only one item, and must not be null.
+
+    In the case of Individual:
+        The individual that bares the phenotype. There may be no known genomic
+        concepts that have been shown to be directly associated to the phenotype.
+
+    In the case of Sample:
+        The sample that bares the phenotype. In this case, the phenotype
+        does not apply to the entire individual. For example, a sample may be
+        metastatic, but that phenotype does not apply to the entire individual.
+        There may be may be many samples from the individual that are not metastatic.
+
+  */
+  union {null,array<org.ga4gh.models.Feature>,org.ga4gh.models.Individual,org.ga4gh.models.Sample} subject = null;
 
  /**
     The evidence for this specific instance of association between the

--- a/src/main/resources/avro/genotypephenotypemethods.avdl
+++ b/src/main/resources/avro/genotypephenotypemethods.avdl
@@ -129,9 +129,9 @@ record SearchFeaturesRequest {
 /** This is the response from `POST /genotypephenotype/search` expressed as JSON. */
 record SearchFeaturesResponse {
   /**
-  The list of matching FeaturePhenotypeAssociation.
+  The list of matching PhenotypeAssociation.
   */
-  array<org.ga4gh.models.FeaturePhenotypeAssociation> associations = [];
+  array<org.ga4gh.models.PhenotypeAssociation> associations = [];
 
   /**
   The continuation token, which is used to page through large result sets.


### PR DESCRIPTION
The PhenotypeAssociation is now allowed to link to Individuals and Samples.
This change was originally proposed in: https://github.com/ga4gh/schemas/issues/264#issuecomment-86228509

This also changes the proposed behavior of how Phenotypes are listed for Individuals. Originally it was a simple array embedded in the Individual record. This patch removes that, and replaces it with the ability to link Phenotypes to Individuals using the PhenotypeAssociation structure. 