### PR TITLE
add fastq object

### DIFF
--- a/src/main/resources/avro/reads.avdl
+++ b/src/main/resources/avro/reads.avdl
@@ -148,6 +148,24 @@ record ReadGroupSet {
   // referenceSet.
 }
 
+/**
+A read sequence corresponds to one read entry in a fastq file, if the
+quality string is present, or a fasta entry, if absent.
+*/
+record ReadSequence {
+  /** Sequence identifier. */
+  string id;
+
+  /** Description. */
+  union { null, string } description = null;
+
+  /** Raw read sequence. */
+  string sequence;
+
+  /** Quality values. */
+  union { null, string } quality = null;
+}
+
 /** A linear alignment can be represented by one CIGAR string. */
 record LinearAlignment {
   /** The position of this alignment. */


### PR DESCRIPTION
This adds the ReadSequence object which is intended to store the raw read sequence as described by a fastq file (with quality string) or a fasta file (without).  Storing the raw read sequence accomplishes several things:

1) retrieval of mate pair sequence #310 would now be achievable with an id search on ReadSequence instead of ReadAlignment
2) this allows direct raw sequence retrieval for quantification methods that do not use aligned reads (ex: http://pachterlab.github.io/kallisto/about.html)  Previously, the fastq would have to be reconstructed downstream from the ReadAlignment CIGAR and Reference sequence.
3) processing of read data has to be done to get a ReadAlignment which means some decisions have been made for anyone requesting that aligned data.  Access to raw sequence allows an investigator to make their own decisions regarding alignment parameters, etc.
4) unless I'm mistaken this would be the only way to access unaligned reads in the initial data as even the (un-implemented) read is described as having alignment data.  This is a further complication for item (2).