### PR TITLE
Fixed the type of beacon's queries field.

### DIFF
--- a/src/main/resources/avro/beacon.avdl
+++ b/src/main/resources/avro/beacon.avdl
@@ -130,7 +130,7 @@ record BeaconInformationResource {
   union{ null, string } auth = null;
 
   /** Examples of interesting queries, e.g. a few queries demonstrating different types of responses. */
-  union{ null, string } queries = null;
+  union{ null, array<QueryResource> } queries = null;
 }
 
 /**


### PR DESCRIPTION
String did not make much sense and was most likely a bug.