### PR TITLE
Removed beacon's email field.

### DIFF
--- a/src/main/resources/avro/beacon.avdl
+++ b/src/main/resources/avro/beacon.avdl
@@ -123,9 +123,6 @@ record BeaconInformationResource {
   /** URL to the homepage for this beacon. */
   union{ null, string } homepage = null;
 
-  /** An email address for contact. */
-  union{ null, string } email = null;
-
   /** Auth type. Expected value is OAUTH2. Defaults to NONE. */
   union{ null, string } auth = null;
 


### PR DESCRIPTION
It seems there is very little value in having an email directly in the schema. Contact info can be listed on the beacon home page, possibly with more information and a better way of contacting the maintainer than an email.