### PR TITLE
Wind back graph syntax changes to what the current reference server implements

### DIFF
--- a/src/main/resources/avro/common.avdl
+++ b/src/main/resources/avro/common.avdl
@@ -6,25 +6,6 @@ not have any methods; it is merely a library of types.
 protocol Common {
 
 /**
-A `Position` is an unoriented base in some `Sequence`. A `Position` is
-represented by a sequence name or ID, and a base number on that `Sequence`
-(0-based).
-*/
-record Position {
-  /**
-  The ID of the sequence on which the `Position` is located.
-  */
-  string sequenceId;
-
-  /**
-  The 0-based offset from the start of the forward strand for that `Sequence`.
-  Genomic positions are non-negative integers less than `Sequence` length.
-  */
-  long position;
-}
-
-
-/**
 Indicates the DNA strand associate for some data item.
 * `NEG_STRAND`: The negative (-) strand.
 * `POS_STRAND`:  The postive (+) strand.
@@ -35,90 +16,26 @@ enum Strand {
 }
 
 /**
-A `Side` is an oriented base in some already known sequence. A
-`Side` is represented by a sequence name or ID, a base number on that
-sequence (0-based), and a `Strand` to indicate the forward or reverse-complement
-orientation.
-
-For example, given the sequence "GTGG", the `Side` on that sequence at
-offset 1 in the forward orientation would be the left side of the T/A base pair.
-The base at this `Side` is "T". Alternately, for offset 1 in the reverse
-orientation, the `Side` would be the right side of the T/A base pair, and
-the base at the `Side` is "A".
-
-Offsets added to a `Side` are interpreted as reading along its strand;
-adding to a reverse strand side actually subtracts from its `base.position`
-member.
-
-There is a total ordering on sides, assuming a total ordering on
-`Sequence`s. Sides are sorted by their `Sequence` (as specified by
-`sequenceId` and/or `referenceName`), then within a `Sequence` by their
-`position` offsets, and then finally by `Strand`, with `NEG_STRAND` first, then
-`POS_STRAND`.
+A `Position` is an unoriented base in some `Reference`. A `Position` is
+represented by a `Reference` name, and a base number on that `Reference`
+(0-based).
 */
-record Side {
+record Position {
   /**
-  Base the `Side` is associated with.
+  The name of the `Reference` on which the `Position` is located.
   */
-  Position base;
+  string referenceName;
 
   /**
-  Strand the side is associated with. `POS_STRAND` represents the forward
-  strand, or equivalently the left side of a base, and `NEG_STRAND` represents
-  the reverse strand, or equivalently the right side of a base.
+  The 0-based offset from the start of the forward strand for that `Reference`.
+  Genomic positions are non-negative integers less than `Reference` length.
+  */
+  long position;
 
-  If you need a `Side` without a `Strand`, you need a `Position`.
+  /**
+  Strand the position is associated with.
   */
   Strand strand;
-}
-
-/**
-Represents a sequence of DNA bases.
-
-Does not include any base data. The bases for a `Sequence` are available through
-the `getSequenceBases()` API call.
-*/
-record Sequence {
-  /**
-  The ID of the sequence.
-  */
-  string id;
-  /**
-  The length of the sequence. Must be greater than 0.
-  */
-  long length;
-}
-
-/**
-A `Segment` is a range on a `Sequence`. It does not include any base data. (The
-bases for a `Sequence` are available through the `getSequenceBases()` API call.)
-
-In the sequence "GTGG", the `Segment` starting at index 1 on the forward strand
-with length 2 is the "TG" on the forward strand. The length-2 `Segment` starting
-at index 1 on the reverse strand is "AC", corresponding to the first two base
-pairs of the sequence, or the last two bases of the reverse complement.
-
-A `Segment` has a left and a right end, in its local orientation (i.e. taking
-`Segment.start.strand` to be the `Segment`'s forward strand).
-*/
-record Segment {
-  /**
-  The sequence ID and start index of this `Segment`. This base is the first
-  included in the `Segment`, regardless of orientation.
-  */
-  Side start;
-
-  /**
-  The length of this `Segment`'s sequence. If `start` is on the forward strand,
-  the `Segment` contains the range [`start.base.position`,
-  `start.base.position` + `length`). If `start` is on the reverse strand, the
-  `Segment` contains the range (`start.base.position` - `length`,
-  `start.base.position`]. This is equivalent to starting from the side indicated
-  by `start`, and traversing through that base out to the specified length.
-
-  A `Segment` may have zero length.
-  */
-  long length;
 }
 
 /**

--- a/src/main/resources/avro/reads.avdl
+++ b/src/main/resources/avro/reads.avdl
@@ -137,7 +137,7 @@ record ReadGroupSet {
 /** A linear alignment can be represented by one CIGAR string. */
 record LinearAlignment {
   /** The position of this alignment. */
-  Side position;
+  Position position;
 
   /**
   The mapping quality of this alignment. Represents how likely
@@ -238,16 +238,15 @@ record ReadAlignment {
   /**
   Whether this alignment is supplementary. Equivalent to SAM flag 0x800.
   Supplementary alignments are used in the representation of a chimeric
-  alignment, which follows nonreference adjacencies not describable as indels.
-  In a chimeric alignment, a read is split into multiple alignments that
-  may map to different reference contigs. The first alignment in the read will
-  be designated as the representative alignment; the remaining alignments will
-  be designated as supplementary alignments. These alignments may have different
-  mapping quality scores.
+  alignment. In a chimeric alignment, a read is split into multiple
+  linear alignments that map to different reference contigs. The first
+  linear alignment in the read will be designated as the representative alignment;
+  the remaining linear alignments will be designated as supplementary alignments.
+  These alignments may have different mapping quality scores.
 
-  In each alignment in a chimeric alignment, the read will be hard clipped. The
-  `alignedSequence` and `alignedQuality` fields in the alignment record will
-  only represent the bases for its respective alignment.
+  In each linear alignment in a chimeric alignment, the read will be hard clipped.
+  The `alignedSequence` and `alignedQuality` fields in the alignment record will
+  only represent the bases for its respective linear alignment.
   */
   union { null, boolean } supplementaryAlignment = null;
 
@@ -273,7 +272,7 @@ record ReadAlignment {
   The mapping of the primary alignment of the `(readNumber+1)%numberReads`
   read in the fragment. It replaces mate position and mate strand in SAM.
   */
-  union { null, Side } nextMatePosition = null;
+  union { null, Position } nextMatePosition = null;
 
   /**
   A map of additional read alignment information.

--- a/src/main/resources/avro/referencemethods.avdl
+++ b/src/main/resources/avro/referencemethods.avdl
@@ -99,11 +99,6 @@ record SearchReferencesRequest {
   union { null, string } referenceSetId = null;
 
   /**
-  If nonempty, return only `Reference`s on `Sequence`s with IDs in the list.
-  */
-  array<string> sequenceIds = [];
-
-  /**
   If nonempty, return references which match any of the given `md5checksums`.
   See `Reference::md5checksum` for details.
   */
@@ -117,12 +112,6 @@ record SearchReferencesRequest {
   Note that different versions will have different sequences.
   */
   array<string> accessions = [];
-
-  /**
-  If nonempty, return references that have one of the specified names. The name
-  specified must match the reference's name exactly, and is case sensitive.
-  */
-  array<string> referenceNames = [];
 
   /**
   Specifies the maximum number of results to return in a single page.
@@ -211,7 +200,7 @@ record ListReferenceBasesRequest {
 /** The response from `GET /references/{id}/bases` expressed as JSON. */
 record ListReferenceBasesResponse {
   /**
-  The offset position (0-based) of the given `sequence` from the start of this
+  The offset position (0-based) of the given sequence from the start of this
   `Reference`. This value will differ for each page in a paginated request.
    */
   long offset = 0;
@@ -240,107 +229,5 @@ ListReferenceBasesResponse getReferenceBases(
   string id,
   /** Additional request parameters to restrict the query. */
   ListReferenceBasesRequest request) throws GAException;
-
-/******************  /sequences/search  *********************/
-/**
-This request maps to the body of `POST /sequences/search` as JSON. Specifies a
-number of filters, all of which must be satisfied by each result returned.
-*/
-record SearchSequencesRequest {
-  /**
-  If not null, return only `Sequence`s that appear in the indicated
-  `ReferenceSet`, or any included `ReferenceSet`s.
-
-  If null, `variantSetId` must not be null.
-  */
-  union { null, string } referenceSetId = null;
-
-  /**
-  If not null, return only `Sequence`s that are part of the indicated
-  `VariantSet`.
-
-  If null, `referenceSetId` must not be null.
-  */
-  union { null, string } variantSetId = null;
-
-  /**
-  Specifies the maximum number of results to return in a single page.
-  If unspecified, a system default will be used.
-  */
-  union { null, int } pageSize = null;
-
-  /**
-  The continuation token, which is used to page through large result sets.
-  To get the next page of results, set this parameter to the value of
-  `nextPageToken` from the previous response.
-  */
-  union { null, string } pageToken = null;
-}
-
-/**
-This is the response from `POST /sequences/search` expressed as JSON.
-*/
-record SearchSequencesResponse {
-  /**
-  The list of matching `Sequence`s.
-  */
-  array<org.ga4gh.models.Sequence> sequences = [];
-
-  /**
-  The continuation token, which is used to page through large result sets.
-  Provide this value in a subsequent request to return the next page of
-  results. This field will be empty if there aren't any additional results.
-  */
-  union { null, string } nextPageToken = null;
-}
-
-/**
-Gets `Sequence`s that match the search criteria.
-
-`POST /sequences/search` must accept a JSON version of `SearchSequencesRequest`
-as the post body and will return a JSON version of `SearchSequencesResponse`.
-*/
-SearchSequencesResponse searchSequences(
-  /**
-  This request maps to the body of `POST /sequences/search` as
-  JSON.
-  */
-  SearchSequencesRequest request) throws GAException;
-
-/****************  /sequences/{id}/bases  *******************/
-/**
-The query parameters for a request to `GET /sequences/{id}/bases`, for
-example:
-
-`GET /sequences/c95d4520-8c63-45f1-924d-6a9604a919fb/bases?start=100&end=200`
-*/
-
-/** The response from `GET /sequences/{id}/bases` expressed as JSON. */
-record GetSequenceBasesResponse {
-  /**
-  The offset position (0-based) of the returned string in the sequence. This
-  value should match the start request parameter, or be 0.
-   */
-  long offset = 0;
-
-  /**
-  A substring of the sequence requested. Bases are represented as IUPAC-IUB
-  codes; this string matches the regexp `[ACGTMRWSYKVHDBN]*`.
-  */
-  string sequence;
-}
-
-/**
-Lists bases by sequence ID and optional range. `GET /sequences/{id}/bases`
-will return a JSON version of `GetSequenceBasesResponse`. Works for sequences
-with associated `Reference`s, as well as novel sequences that come with
-`VariantSet`s.
-*/
-GetSequenceBasesResponse getSequenceBases(
-    /** The ID of the sequence. */
-    string id,
-    /** Additional request parameters to restrict the query. */
-    union {null, long} start = null,
-    union {null, long} end) throws GAException;
 
 }

--- a/src/main/resources/avro/references.avdl
+++ b/src/main/resources/avro/references.avdl
@@ -12,12 +12,7 @@ A `Reference` is a canonical assembled contig, intended to act as a
 reference coordinate space for other genomic annotations. A single
 `Reference` might represent the human chromosome 1, for instance.
 
-`Reference`s are designed to be immutable. When extending a `ReferenceSet` with
-new `Reference`s, the existing `References` should not be changed. Newly added
-`Reference` `Sequence`s may be children of existing `Reference` `Sequence`s, but
-existing `Reference` `Sequence`s should not be made to be children of newly
-added `Reference` `Sequence`s.
-
+`Reference`s are designed to be immutable.
 */
 record Reference {
 
@@ -26,15 +21,8 @@ record Reference {
   */
   string id;
 
-  /**
-  The location in the `Sequence` on which this `Reference` occurs. May not be
-  null, although it may happen to be the same as the ID of the `Reference`. The
-  actual `Sequence` bases for a `Reference` are available through the
-  `getSequenceBases()` API call on this `Reference`'s `Sequence`.
-
-  Multiple `Reference`s on the same `Sequence` may not overlap.
-  */
-  Segment location;
+  /** The length of this reference's sequence. */
+  long length;
 
   /**
   The MD5 checksum uniquely representing this `Reference` as a lower-case
@@ -49,10 +37,9 @@ record Reference {
   string name;
 
   /**
-  The URI from which the sequence was obtained.
-  Specifies a FASTA format file/string with one name, sequence pair.
-  In most cases, clients should call the `getSequenceBases()` or
-  `getReferenceBases()` methods to obtain sequence bases for a `Reference`
+  The URI from which the sequence was obtained. Specifies a FASTA format
+  file/string with one name, sequence pair. In most cases, clients should call
+  the `getReferenceBases()` method to obtain sequence bases for a `Reference`
   instead of attempting to retrieve this URI.
   */
   union { null, string } sourceURI = null;
@@ -81,18 +68,12 @@ record Reference {
   /** ID from http://www.ncbi.nlm.nih.gov/taxonomy (e.g. 9606->human). */
   union { null, int } ncbiTaxonId = null;
 
-  /** whether this reference is primary, part of the core coordinate system, or not */
-  boolean isPrimary = true;
 }
 
 /**
 A `ReferenceSet` is a set of `Reference`s which typically comprise a
 reference assembly, such as `GRCh38`. A `ReferenceSet` defines a common
 coordinate space for comparing reference-aligned experimental data.
-
-`ReferenceSet`s are composeable: a `ReferenceSet` may incorporate all of the
-`Reference`s from one or more other `ReferenceSet`s via the
-`includedReferenceSet`s array.
 */
 
 record ReferenceSet {
@@ -109,23 +90,6 @@ record ReferenceSet {
   union { null, array<string> } referenceIds = null;
 
   /**
-  The IDs of `ReferenceSet`s that are included in this set, allowing extension
-  from a core e.g. provided by GRC or another provider.
-
-  A `ReferenceSet` is not allowed to include itself, either directly by ID, or
-  indirectly or transitively through another `ReferenceSet`.
-
-  `Reference`s from the included `ReferenceSet`s are considered to be part of
-  this one. If multiple included `ReferenceSet`s provide a `Reference`, only one
-  copy is taken to exist in this `ReferenceSet`. Since different `Reference`s on
-  a `Sequence` may not overlap, it is illegal to include `ReferenceSet`s which
-  when taken together would create such an overlap, or to have such an overlap
-  between a `Reference` from an included `ReferenceSet` and one that appears
-  directly in this `ReferenceSet`.
-  */
-  array<string> includedReferenceSets = [];
-
-  /**
   Order-independent MD5 checksum which identifies this `ReferenceSet`.
 
   To compute this checksum, make a list of `Reference.md5checksum` for all
@@ -139,7 +103,7 @@ record ReferenceSet {
   ID from http://www.ncbi.nlm.nih.gov/taxonomy (e.g. 9606->human) indicating
   the species which this assembly is intended to model. Note that contained
   `Reference`s may specify a different `ncbiTaxonId`, as assemblies may
-  contain reference `Sequence`s which do not belong to the modeled species, e.g.
+  contain reference sequences which do not belong to the modeled species, e.g.
   EBV in a human reference genome.
   */
   union { null, int } ncbiTaxonId = null;
@@ -147,7 +111,7 @@ record ReferenceSet {
   /** Optional free text description of this reference set. */
   union { null, string } description = null;
 
-  // next information about the source of the `Sequence`s
+  // next information about the source of the sequences
 
   /** Public id of this reference set, such as `GRCh37`. */
   union { null, string } assemblyId = null;
@@ -163,7 +127,7 @@ record ReferenceSet {
 
   /**
   A reference set may be derived from a source if it contains
-  additional `Sequence`s, or some of the `Sequence`s within it are derived
+  additional sequences, or some of the sequences within it are derived
   (see the definition of `isDerived` in `Reference`).
   */
   boolean isDerived = false;

--- a/src/main/resources/avro/sequenceAnnotationmethods.avdl
+++ b/src/main/resources/avro/sequenceAnnotationmethods.avdl
@@ -27,10 +27,15 @@ protocol SequenceAnnotationMethods {
     union { null, string } parentId;
 
     /**
-    If specified, this query matches only annotations which overlap this Segment
-    of a Sequence.
+    If specified, this query matches only annotations which overlap this part of
+    a `Reference`.
+    
+    All three of `referenceName`, `start`, and `end` must be specified as a
+    group.
     */
-    union { null, org.ga4gh.models.Segment } range = null;
+    union { null, string } referenceName = null;
+    union { null, long } start = null;
+    union { null, long } end = null;
 
     // TODO: Fix this field. Clarify semantics around how OntologyTerm matching works, or
     // change the Ontology term field on the feature.

--- a/src/main/resources/avro/sequenceAnnotations.avdl
+++ b/src/main/resources/avro/sequenceAnnotations.avdl
@@ -64,8 +64,13 @@ protocol SequenceAnnotations {
     Note that we are fusing parts of UCSC BedGraph and Wiggle syntax.
     The segment is being fully annotated, but can be divided into bins.
     If you have gaps, you need to define a sequence of such Wiggles.
+    
+    All three of `referenceName`, `start`, and `end` must be specified as a
+    group.
     */
-    Segment location;
+    union { null, string } referenceName = null;
+    union { null, long } start = null;
+    union { null, long } end = null;
 
     /**
     The values associated to this region.
@@ -115,8 +120,13 @@ protocol SequenceAnnotations {
 
     /**
     Genomic location.
+    
+    All three of `referenceName`, `start`, and `end` must be specified as a
+    group.
     */
-    Segment location;
+    union { null, string } referenceName = null;
+    union { null, long } start = null;
+    union { null, long } end = null;
 
     /**
     Strand of the feature, or null if unstranded

--- a/src/main/resources/avro/variantmethods.avdl
+++ b/src/main/resources/avro/variantmethods.avdl
@@ -8,9 +8,10 @@ import idl "variants.avdl";
 /** This request maps to the body of `POST /variantsets/search` as JSON. */
 record SearchVariantSetsRequest {
   /**
-  The Dataset to search.
+  If specified, will restrict the query to variant sets within the
+  given datasets.
   */
-  string datasetId;
+  array<string> datasetIds = [];
 
   /**
   Specifies the maximum number of results to return in a single page.
@@ -64,16 +65,14 @@ org.ga4gh.models.VariantSet getVariantSet(
 /******************  /variants/search  *********************/
 /** This request maps to the body of `POST /variants/search` as JSON. */
 record SearchVariantsRequest {
-  /**
-  The VariantSet to search.
-  */
-  string variantSetId;
+  /** Required. The IDs of the variant sets to search over. */
+  array<string> variantSetIds = [];
 
   /**
   Only return variants which have exactly this name (case-sensitive, exact
   match).
   */
-  union { null, string } name = null;
+  union { null, string } variantName = null;
 
   /**
   Only return variant calls which belong to call sets with these IDs.
@@ -82,10 +81,23 @@ record SearchVariantsRequest {
   */
   union { null, array<string> } callSetIds = null;
 
+  /** Required. Only return variants on this reference. */
+  string referenceName;
+
   /**
-  Only return variants overlapping this `Segment`.
+  Required. The beginning of the window (0-based, inclusive) for
+  which overlapping variants should be returned.
+  Genomic positions are non-negative integers less than reference length.
+  Requests spanning the join of circular genomes are represented as
+  two requests one on each side of the join (position 0).
   */
-  org.ga4gh.models.Segment searchSegment;
+  long start;
+
+  /**
+  Required. The end of the window (0-based, exclusive) for which overlapping
+  variants should be returned.
+  */
+  long end;
 
   /**
   Specifies the maximum number of results to return in a single page.
@@ -131,24 +143,14 @@ SearchVariantsResponse searchVariants(
   /** This request maps to the body of `POST /variants/search` as JSON. */
   SearchVariantsRequest request) throws GAException;
 
-/**************** /variants/{id} *******************/
-/**
-Gets a `Variant` by ID.
-`GET /variants/{id}` will return a JSON version of `Variant`.
-*/
-org.ga4gh.models.Variant getVariant(
-  /**
-  The ID of the `Variant`.
-  */
-  string id) throws GAException;
-
 /******************  /callsets/search  *********************/
 /** This request maps to the body of `POST /callsets/search` as JSON. */
 record SearchCallSetsRequest {
   /**
-  The VariantSet to search.
+  If specified, will restrict the query to call sets within the
+  given variant sets.
   */
-  string variantSetId;
+  array<string> variantSetIds = [];
 
   /**
   Only return call sets with this name (case-sensitive, exact match).

--- a/src/main/resources/avro/variantmethods.avdl
+++ b/src/main/resources/avro/variantmethods.avdl
@@ -8,10 +8,9 @@ import idl "variants.avdl";
 /** This request maps to the body of `POST /variantsets/search` as JSON. */
 record SearchVariantSetsRequest {
   /**
-  If specified, will restrict the query to variant sets within the
-  given datasets.
+  The `Dataset` to search.
   */
-  array<string> datasetIds = [];
+  string datasetId;
 
   /**
   Specifies the maximum number of results to return in a single page.
@@ -65,8 +64,10 @@ org.ga4gh.models.VariantSet getVariantSet(
 /******************  /variants/search  *********************/
 /** This request maps to the body of `POST /variants/search` as JSON. */
 record SearchVariantsRequest {
-  /** Required. The IDs of the variant sets to search over. */
-  array<string> variantSetIds = [];
+  /**
+  The `VariantSet` to search.
+  */
+  string variantSetId;
 
   /**
   Only return variants which have exactly this name (case-sensitive, exact
@@ -143,14 +144,24 @@ SearchVariantsResponse searchVariants(
   /** This request maps to the body of `POST /variants/search` as JSON. */
   SearchVariantsRequest request) throws GAException;
 
+/**************** /variants/{id} *******************/
+/**
+Gets a `Variant` by ID.
+`GET /variants/{id}` will return a JSON version of `Variant`.
+*/
+org.ga4gh.models.Variant getVariant(
+  /**
+  The ID of the `Variant`.
+  */
+  string id) throws GAException;
+
 /******************  /callsets/search  *********************/
 /** This request maps to the body of `POST /callsets/search` as JSON. */
 record SearchCallSetsRequest {
-  /**
-  If specified, will restrict the query to call sets within the
-  given variant sets.
+  /*
+  The VariantSet to search.
   */
-  array<string> variantSetIds = [];
+  string variantSetId;
 
   /**
   Only return call sets with this name (case-sensitive, exact match).

--- a/src/main/resources/avro/variants.avdl
+++ b/src/main/resources/avro/variants.avdl
@@ -106,6 +106,16 @@ and phasing. For example, a call might assign a probability of 0.32 to
 the occurrence of a SNP named rs1234 in a call set with the name NA12345.
 */
 record Call {
+
+  /**
+  The name of the call set this variant call belongs to.
+  If this field is not present, the ordering of the call sets from a
+  `SearchCallSetsRequest` over this `VariantSet` is guaranteed to match
+  the ordering of the calls on this `Variant`.
+  The number of results will also be the same.
+  */
+  union { null, string } callSetName = null;
+
   /**
   The ID of the call set this variant call belongs to.
 
@@ -182,14 +192,29 @@ record Variant {
   union { null, long } updated = null;
 
   /**
-  The sequence:start-end region (with orientation) in the `ReferenceSet` that
-  this variant replaces.
+  The reference on which this variant occurs.
+  (e.g. `chr20` or `X`)
   */
-  Segment location;
+  string referenceName;
 
   /**
-  The reference bases for this variant. They occupy the variant's `Region` in
-  the reference.
+  The start position at which this variant occurs (0-based).
+  This corresponds to the first base of the string of reference bases.
+  Genomic positions are non-negative integers less than reference length.
+  Variants spanning the join of circular genomes are represented as
+  two variants one on each side of the join (position 0).
+  */
+  long start;
+
+  /**
+  The end position (exclusive), resulting in [start, end) closed-open interval.
+  This is typically calculated by `start + referenceBases.length`.
+  */
+  long end;
+
+
+  /**
+  The reference bases for this variant. They start at the given start position.
   */
   string referenceBases;
 
@@ -197,7 +222,7 @@ record Variant {
   The bases that appear instead of the reference bases. Multiple alternate
   alleles are possible.
   */
-  array<string> alternateBases;
+  array<string> alternateBases = [];
 
   /**
   A map of additional variant information.
@@ -209,7 +234,7 @@ record Variant {
   determination of genotype with respect to this variant. `Call`s in this array
   are implicitly associated with this `Variant`.
   */
-  array<Call> calls;
+  array<Call> calls = [];
 }
 
 }


### PR DESCRIPTION
This is an attempt, as discussed on the call this morning, to undo some of the syntax changes introduced alongside the graph features. I'm mostly targeting the schemas as they were at e6d6074 which @dcolligan recommended, but I'm keeping some of the newer features which the server does actually implement (like a couple of the get by ID methods, and the use of `Positions` instead of what we used to call `Side`s).

I've only touched a few of the files: the ones that adding graph support actually modified, and a couple of the other APIs that depended on the stuff I removed and had to be tweaked in order to compile. Those other APIs still need to be backed out onto topic branches; @macieksmuga is going to handle that after we finish backing out the graph features.

If we take this into master, I think this leaves the server more or less correctly implementing everything it actually does implement. There are some places where the spec specifies an array, and the server only supports a 1-element array. There are also still a few new features in the files I touched that the server may or may not have picked up on, mostly to do with the difference between full string and substring search. I didn't roll those back; the server will just have to change its semantics slightly after this is in, if it isn't doing the new semantics already.

Here's a changelog:

* Removed `Segment`s.
* Replaced `Segment`s with triples of a `Reference` name, start, and length.
* Removed `Sequence`s, and all methods thereof.
* Changed references to `Sequence` IDs to use `Reference` names instead.
* Removed `Side`s.
* Added `Strand` back to `Position`.
* Removed `sequenceIds` and `referenceNames` from `SearchReferencesRequest`.
* Removed `isPrimary` from `Reference`.
* Removed `ReferenceSet` inheritance and the `includedReferenceSets` field.
* Replaced `SearchVariantSetsRequest`'s `datasetId` with the old `datasetIds`.
* Replaced `SearchVariantsRequest`'s `variantSetId` with the old `variantSetIds`.
* Replaced `SearchVariantsRequest`'s `name` with the old `variantName`.
* Removed the unimplemented `/variants/<id>` method.
* Replaced `SearchCallSetsRequest`'s `variantSetId` with the old `variantSetIds`.
* Added `callSetName` back to `Call`.
* Fixed a couple arrays to default to empty.
