### PR TITLE
Changed variantName back to name as in PR #239.

### DIFF
--- a/src/main/resources/avro/variantmethods.avdl
+++ b/src/main/resources/avro/variantmethods.avdl
@@ -73,7 +73,7 @@ record SearchVariantsRequest {
   Only return variants which have exactly this name (case-sensitive, exact
   match).
   */
-  union { null, string } variantName = null;
+  union { null, string } name = null;
 
   /**
   Only return variant calls which belong to call sets with these IDs.


### PR DESCRIPTION
This reverts a minor change made in #352. Changes to the reference server are trivial, and can be completed as part of a wider cleanup.