### PR TITLE
Remove the name argument from variant search.

### DIFF
--- a/src/main/resources/avro/variantmethods.avdl
+++ b/src/main/resources/avro/variantmethods.avdl
@@ -70,12 +70,6 @@ record SearchVariantsRequest {
   string variantSetId;
 
   /**
-  Only return variants which have exactly this name (case-sensitive, exact
-  match).
-  */
-  union { null, string } variantName = null;
-
-  /**
   Only return variant calls which belong to call sets with these IDs.
   If an empty array, returns variants without any call objects.
   If null, returns all variant calls.


### PR DESCRIPTION
This PR removes the ``name`` parameter from the ``SearchVariants`` method. This is motivated by the ongoing attempt to sync the schema with what can be implemented effectively in the reference server. Since htslib does not provide this functionality, we cannot implement this query without filtering over potentially millions of variants, leading to very undesirable server behaviour.

During yesterdays refVar call it was decided that removing this functionality was a good option. The other option being to raise a HTTP 501 Not Implemented when a user attempts to search by name in the reference server.