### PR TITLE
Made a CallSet belong to one VariantSet.

### DIFF
--- a/src/main/resources/avro/variants.avdl
+++ b/src/main/resources/avro/variants.avdl
@@ -79,8 +79,8 @@ record CallSet {
   /** The sample this call set's data was generated from. */
   union { null, string } sampleId;
 
-  /** The IDs of the variant sets this call set has calls in. */
-  array<string> variantSetIds = [];
+  /** The ID of the variant set this call set has calls in. */
+  string variantSetId;
 
   /** The date this call set was created in milliseconds from the epoch. */
   union { null, long } created = null;


### PR DESCRIPTION
In line with recent  simplifications, this PR changes a CallSet such it refers back to exactly one variantSet. In the reference server, a CallSet is just some metadata about a column in some VCF files and so can only ever belong to one variant set.

