### PR TITLE
Simplified reference methods.

### DIFF
--- a/src/main/resources/avro/referencemethods.avdl
+++ b/src/main/resources/avro/referencemethods.avdl
@@ -12,22 +12,20 @@ as JSON.
 */
 record SearchReferenceSetsRequest {
   /**
-  If nonempty, return the reference sets which match any of the given
-  `md5checksum`s. See `ReferenceSet::md5checksum` for details.
+  If not null, return the reference sets for which the
+  `md5checksum` matches this string (case-sensitive, exact match).
+  See `ReferenceSet::md5checksum` for details.
   */
-  array<string> md5checksums = [];
+  union { null, string } md5checksum = null;
 
   /**
-  If nonempty, return reference sets for which the accession
-  matches this string. Best to give a version number (e.g. `GCF_000001405.26`).
-  If only the main accession number is given then all records with
-  that main accession will be returned, whichever version.
-  Note that different versions will have different sequences.
+  If not null, return the reference sets for which the `accession`
+  matches this string (case-sensitive, exact match).
   */
-  array<string> accessions = [];
+  union { null, string } accession = null;
 
   /**
-  If not null, return reference sets for which the `assemblyId`
+  If not null, return the reference sets for which the `assemblyId`
   matches this string (case-sensitive, exact match).
   */
   union { null, string } assemblyId = null;
@@ -99,19 +97,17 @@ record SearchReferencesRequest {
   string referenceSetId;
 
   /**
-  If nonempty, return references which match any of the given `md5checksums`.
-  See `Reference::md5checksum` for details.
+  If not null, return the references for which the
+  `md5checksum` matches this string (case-sensitive, exact match).
+  See `ReferenceSet::md5checksum` for details.
   */
-  array<string> md5checksums = [];
+  union { null, string } md5checksum = null;
 
   /**
-  If nonempty, return references for which the accession
-  matches this string. Best to give a version number e.g. `GCF_000001405.26`.
-  If only the main accession number is given then all records with
-  that main accession will be returned, whichever version.
-  Note that different versions will have different sequences.
+  If not null, return the references for which the `accession`
+  matches this string (case-sensitive, exact match).
   */
-  array<string> accessions = [];
+  union { null, string } accession = null;
 
   /**
   Specifies the maximum number of results to return in a single page.


### PR DESCRIPTION
This PR changes the reference and referenceSet search methods to accept single filter arguments rather than lists. The complex semantics of searching accessions is also reduced to simple string matching. This is part of a wider effort to simplify the schema so that it can be easily implemented and the semantics of each request is clear.

Performance arguments for allowing a client search for several references or referenceSets at once seem difficult to sustain. References are not something that a client needs to search for very often, so a few more server calls will make no difference in practice.

The semantics for searching over accessions depends on the server parsing accession numbers held within a string field. If this sort of functionality is required, then a formal model of the accession number object should be made, so that string parsing/construction is not required by either the client of the server. 
