### PR TITLE
removed CallSet; introduced NamedSample

### DIFF
--- a/src/main/resources/avro/metadata.avdl
+++ b/src/main/resources/avro/metadata.avdl
@@ -127,23 +127,15 @@ record Sample {
   string datasetId;
 
   /**
-  Sample name in the dataset. This name uniquely identifies the sample in the
-  dataset.
+  Submitted sample name in the dataset. This name uniquely identifies the
+  sample in the dataset.
   */
   string name;
 
   /**
-  The NCBI/EBI BioSample identifier of this sample. Different Sample objects
-  may have the same biosampleId.
+  Key-value pairs for additional sample information
   */
-  union { null, string } biosampleId = null;
-
-  /**
-  A globally unique ID, derived by some agreed upon scheme so that we can find
-  equivalent Sample's in different datasets and servers/implementations.
-  Typically, sequencing libraries and guids have a one-to-one relationship.
-  */
-  union { null, string } guid = null;
+  map<array<string>> info = {};
 }
 
 }

--- a/src/main/resources/avro/metadata.avdl
+++ b/src/main/resources/avro/metadata.avdl
@@ -109,4 +109,44 @@ record Dataset {
 
 }
 
+/**
+In a Dataset, a sample is identified by its name that shall be unique in the
+Dataset. This name typically appears in a @RG line in a BAM file and in the
+sample header line of a VCF file. Unrelated samples in different Datasets may
+have the same name. DatasetSample is only meant to be embedded in SampleGroup,
+not referenced by other objects.
+*/
+record DatasetSample {
+
+  string datasetId;
+
+  /**
+  The sample name in the Dataset referred by datasetId
+  */
+  string sampleName;
+}
+
+/**
+A SampleGroup connects samples in different Datasets that have the same origin.
+A typical scenario is that samples from several Datasets are aggregated and
+reanalyzed, which result in a new Dataset.
+*/
+record SampleGroup {
+  /**
+  ID of this sample group
+  */
+  string id;
+
+  /**
+  The NCBI/EBI BioSample identifier of this sample group. Different samples
+  groups may have the same biosampleId.
+  */
+  string biosampleId;
+
+  /**
+  Samples in different Datasets which are considered the same
+  */
+  array<DatasetSample> samples;
+}
+
 }

--- a/src/main/resources/avro/metadata.avdl
+++ b/src/main/resources/avro/metadata.avdl
@@ -110,12 +110,11 @@ record Dataset {
 }
 
 /**
-In a Dataset, a sample is identified by its name that shall be unique in the
-Dataset. This name typically appears in a @RG line in a BAM file and in the
-sample header line of a VCF file. Unrelated samples in different Datasets may
-have the same sample name.
+A sample uniquely named in a Dataset. The sample name typically appears in a
+@RG line in a BAM file and in the sample header line of a VCF file. Unrelated
+samples in different Datasets may have the same sample name.
 */
-record Sample {
+record NamedSample {
   /**
   Identifier of this sample
   */

--- a/src/main/resources/avro/metadata.avdl
+++ b/src/main/resources/avro/metadata.avdl
@@ -113,40 +113,37 @@ record Dataset {
 In a Dataset, a sample is identified by its name that shall be unique in the
 Dataset. This name typically appears in a @RG line in a BAM file and in the
 sample header line of a VCF file. Unrelated samples in different Datasets may
-have the same name. DatasetSample is only meant to be embedded in SampleGroup,
-not referenced by other objects.
+have the same sample name.
 */
-record DatasetSample {
-
-  string datasetId;
-
+record Sample {
   /**
-  The sample name in the Dataset referred by datasetId
-  */
-  string sampleName;
-}
-
-/**
-A SampleGroup connects samples in different Datasets that have the same origin.
-A typical scenario is that samples from several Datasets are aggregated and
-reanalyzed, which result in a new Dataset.
-*/
-record SampleGroup {
-  /**
-  ID of this sample group
+  Identifier of this sample
   */
   string id;
 
   /**
-  The NCBI/EBI BioSample identifier of this sample group. Different samples
-  groups may have the same biosampleId.
+  The identifier of the dataset this sample belongs to
   */
-  string biosampleId;
+  string datasetId;
 
   /**
-  Samples in different Datasets which are considered the same
+  Sample name in the dataset. This name uniquely identifies the sample in the
+  dataset.
   */
-  array<DatasetSample> samples;
+  string name;
+
+  /**
+  The NCBI/EBI BioSample identifier of this sample. Different Sample objects
+  may have the same biosampleId.
+  */
+  union { null, string } biosampleId = null;
+
+  /**
+  A globally unique ID, derived by some agreed upon scheme so that we can find
+  equivalent Sample's in different datasets and servers/implementations.
+  Typically, sequencing libraries and guids have a one-to-one relationship.
+  */
+  union { null, string } guid = null;
 }
 
 }

--- a/src/main/resources/avro/reads.avdl
+++ b/src/main/resources/avro/reads.avdl
@@ -77,7 +77,7 @@ record ReadGroup {
   union { null, string } description = null;
 
   /** The sample this read group's data was generated from. */
-  union { null, string } sampleId;
+  union { null, string } sampleName;
 
   /** The experiment used to generate this read group. */
   union { null, Experiment } experiment;

--- a/src/main/resources/avro/variantmethods.avdl
+++ b/src/main/resources/avro/variantmethods.avdl
@@ -70,11 +70,11 @@ record SearchVariantsRequest {
   string variantSetId;
 
   /**
-  Only return variant calls which belong to call sets with these IDs.
+  Only return variant calls which belong to samples with these IDs.
   If an empty array, returns variants without any call objects.
   If null, returns all variant calls.
   */
-  union { null, array<string> } callSetIds = null;
+  union { null, array<string> } sampleNames = null;
 
   /** Required. Only return variants on this reference. */
   string referenceName;
@@ -112,8 +112,8 @@ record SearchVariantsRequest {
 record SearchVariantsResponse {
   /**
   The list of matching variants.
-  If the `callSetId` field on the returned calls is not present,
-  the ordering of the call sets from a `SearchCallSetsRequest`
+  If the `sampleName` field on the returned calls is not present,
+  the ordering of the samples from a `SearchVariantsRequest`
   over the parent `VariantSet` is guaranteed to match the ordering
   of the calls on each `Variant`. The number of results will also be
   the same.
@@ -148,68 +148,3 @@ org.ga4gh.models.Variant getVariant(
   The ID of the `Variant`.
   */
   string id) throws GAException;
-
-/******************  /callsets/search  *********************/
-/** This request maps to the body of `POST /callsets/search` as JSON. */
-record SearchCallSetsRequest {
-  /**
-  The VariantSet to search.
-  */
-  string variantSetId;
-
-  /**
-  Only return call sets with this name (case-sensitive, exact match).
-  */
-  union { null, string } name = null;
-
-  // TODO: Add more ways to search by other metadata
-
-  /**
-  Specifies the maximum number of results to return in a single page.
-  If unspecified, a system default will be used.
-  */
-  union { null, int } pageSize = null;
-
-  /**
-  The continuation token, which is used to page through large result sets.
-  To get the next page of results, set this parameter to the value of
-  `nextPageToken` from the previous response.
-  */
-  union { null, string } pageToken = null;
-}
-
-/** This is the response from `POST /callsets/search` expressed as JSON. */
-record SearchCallSetsResponse {
-  /** The list of matching call sets. */
-  array<org.ga4gh.models.CallSet> callSets = [];
-
-  /**
-  The continuation token, which is used to page through large result sets.
-  Provide this value in a subsequent request to return the next page of
-  results. This field will be empty if there aren't any additional results.
-  */
-  union { null, string } nextPageToken = null;
-}
-
-/**
-Gets a list of `CallSet` matching the search criteria.
-
-`POST /callsets/search` must accept a JSON version of `SearchCallSetsRequest`
-as the post body and will return a JSON version of `SearchCallSetsResponse`.
-*/
-SearchCallSetsResponse searchCallSets(
-  /** This request maps to the body of `POST /callsets/search` as JSON. */
-  SearchCallSetsRequest request) throws GAException;
-
-/****************  /callsets/{id}  *******************/
-/**
-Gets a `CallSet` by ID.
-`GET /callsets/{id}` will return a JSON version of `CallSet`.
-*/
-org.ga4gh.models.CallSet getCallSet(
-  /**
-  The ID of the `CallSet`.
-  */
-  string id) throws GAException;
-
-}

--- a/src/main/resources/avro/variants.avdl
+++ b/src/main/resources/avro/variants.avdl
@@ -41,7 +41,7 @@ record VariantSetMetadata {
 }
 
 /**
-`Variant` and `CallSet` both belong to a `VariantSet`.
+`Variant` belongs to a `VariantSet`.
 `VariantSet` belongs to a `Dataset`.
 The variant set is equivalent to a VCF file.
 */
@@ -58,43 +58,15 @@ record VariantSet {
   string referenceSetId;
 
   /**
+  List of samples that are involved in this variant set.
+  */
+  array<string> sampleNames = [];
+
+  /**
   The metadata associated with this variant set. This is equivalent to
   the VCF header information not already presented in first class fields.
   */
   array<VariantSetMetadata> metadata = [];
-}
-
-/**
-A `CallSet` is a collection of variant calls for a particular sample.
-It belongs to a `VariantSet`. This is equivalent to one column in VCF.
-*/
-record CallSet {
-
-  /** The call set ID. */
-  string id;
-
-  /** The call set name. */
-  union { null, string } name = null;
-
-  /** The sample this call set's data was generated from. */
-  union { null, string } sampleId;
-
-  /** The IDs of the variant sets this call set has calls in. */
-  array<string> variantSetIds = [];
-
-  /** The date this call set was created in milliseconds from the epoch. */
-  union { null, long } created = null;
-
-  /**
-  The time at which this call set was last updated in
-  milliseconds from the epoch.
-  */
-  union { null, long } updated = null;
-
-  /**
-  A map of additional call set information.
-  */
-  map<array<string>> info = {};
 }
 
 /**
@@ -110,21 +82,11 @@ record Call {
   /**
   The name of the call set this variant call belongs to.
   If this field is not present, the ordering of the call sets from a
-  `SearchCallSetsRequest` over this `VariantSet` is guaranteed to match
+  `SearchVariantsRequest` over this `VariantSet` is guaranteed to match
   the ordering of the calls on this `Variant`.
   The number of results will also be the same.
   */
-  union { null, string } callSetName = null;
-
-  /**
-  The ID of the call set this variant call belongs to.
-
-  If this field is not present, the ordering of the call sets from a
-  `SearchCallSetsRequest` over this `VariantSet` is guaranteed to match
-  the ordering of the calls on this `Variant`.
-  The number of results will also be the same.
-  */
-  union { null, string} callSetId = null;
+  union { null, string } sampleName = null;
 
   /**
   The genotype of this variant call.

--- a/src/main/resources/avro/variants.avdl
+++ b/src/main/resources/avro/variants.avdl
@@ -75,13 +75,13 @@ particular `Variant`.
 
 It may include associated information such as quality
 and phasing. For example, a call might assign a probability of 0.32 to
-the occurrence of a SNP named rs1234 in a call set with the name NA12345.
+the occurrence of a SNP named rs1234 in a sample with the name NA12345.
 */
 record Call {
 
   /**
-  The name of the call set this variant call belongs to.
-  If this field is not present, the ordering of the call sets from a
+  The name of the sample this variant call belongs to.
+  If this field is not present, the ordering of the names from a
   `SearchVariantsRequest` over this `VariantSet` is guaranteed to match
   the ordering of the calls on this `Variant`.
   The number of results will also be the same.


### PR DESCRIPTION
This PR removes the unnecessary CallSet object and introduces SampleGroup to keep track of cross-DataSet sample relationship. Note that ReadGroup.sampleName, VariantSet.sampleNames[] and DatasetSample.sampleName all refer to the same information. Different types of data in a Dataset can be related through sampleName. Data in different Datasets are related through SampleGroup.samples.

This PR may contain compiling errors and certainly needs to be polished. I will see the response of others first.