### PR TITLE
strawman provenance support, using a new AnalysisSample object

### DIFF
--- a/src/main/resources/avro/metadata.avdl
+++ b/src/main/resources/avro/metadata.avdl
@@ -104,12 +104,14 @@ record AnalysisSample {
 
   /** The analysis sample. */
   union { null, string } name = null;
+  
+  /** The ID of the dataset this analysis sample belongs to. */
+  string datasetId;
 
-  /** The date this analysis sample object was created in milliseconds from the epoch. */
+  /** When this analysis sample object was created in milliseconds from the epoch. */
   union { null, long } created = null;
 
-  /**
-  The time at which this analysis sample object was last updated in milliseconds from the epoch. */
+  /** When this analysis sample object was last updated in milliseconds from the epoch. */
   union { null, long } updated = null;
 
   /** A map of additional analysis sample information. */

--- a/src/main/resources/avro/metadata.avdl
+++ b/src/main/resources/avro/metadata.avdl
@@ -92,6 +92,32 @@ record Experiment {
 }
 
 /**
+A `SequencerInput` represents prepared tissue intended to be sequenced and analyzed together,
+eventually generating one or more `ReadGroupSet` and/or `CallSet` objects.
+TODO: agree on a formal metadata model to describe where the tissue came from, including
+ways to represent the source organism, sample collection, and sample prep.
+*/
+record SequencerInput {
+
+  /** The sequencer input ID. */
+  string id;
+
+  /** The sequencer input name. */
+  union { null, string } name = null;
+
+  /** The date this sequencer input was created in milliseconds from the epoch. */
+  union { null, long } created = null;
+
+  /**
+  The time at which this sequencer input was last updated in milliseconds from the epoch. */
+  union { null, long } updated = null;
+
+  /** A map of additional sequencer input information. */
+  map<array<string>> info = {};
+}
+
+
+/**
 Represents a group of contextually related data objects of (e.g. all Individuals, Samples, 
 Experiments associated with a particular feature; or e.g. a trio in genetic diagnostics.).
 This concept may be expanded in the future (ontology for describing the type of dataset ...).

--- a/src/main/resources/avro/metadata.avdl
+++ b/src/main/resources/avro/metadata.avdl
@@ -92,27 +92,27 @@ record Experiment {
 }
 
 /**
-A `GoopGlob` represents prepared tissue intended to be sequenced and analyzed together,
+An `AnalysisSample` represents prepared tissue intended to be sequenced and analyzed together,
 eventually generating one or more `ReadGroupSet` and/or `CallSet` objects.
 TODO: agree on a formal metadata model to describe where the tissue came from, including
 ways to represent the source organism, sample collection, and sample prep.
 */
-record GoopGlob {
+record AnalysisSample {
 
-  /** The goop glob ID. */
+  /** The analysis sample ID. */
   string id;
 
-  /** The goop glob name. */
+  /** The analysis sample. */
   union { null, string } name = null;
 
-  /** The date this goop glob was created in milliseconds from the epoch. */
+  /** The date this analysis sample object was created in milliseconds from the epoch. */
   union { null, long } created = null;
 
   /**
-  The time at which this goop glob was last updated in milliseconds from the epoch. */
+  The time at which this analysis sample object was last updated in milliseconds from the epoch. */
   union { null, long } updated = null;
 
-  /** A map of additional goop glob information. */
+  /** A map of additional analysis sample information. */
   map<array<string>> info = {};
 }
 

--- a/src/main/resources/avro/metadata.avdl
+++ b/src/main/resources/avro/metadata.avdl
@@ -92,27 +92,27 @@ record Experiment {
 }
 
 /**
-A `SequencerInput` represents prepared tissue intended to be sequenced and analyzed together,
+A `GoopGlob` represents prepared tissue intended to be sequenced and analyzed together,
 eventually generating one or more `ReadGroupSet` and/or `CallSet` objects.
 TODO: agree on a formal metadata model to describe where the tissue came from, including
 ways to represent the source organism, sample collection, and sample prep.
 */
-record SequencerInput {
+record GoopGlob {
 
-  /** The sequencer input ID. */
+  /** The goop glob ID. */
   string id;
 
-  /** The sequencer input name. */
+  /** The goop glob name. */
   union { null, string } name = null;
 
-  /** The date this sequencer input was created in milliseconds from the epoch. */
+  /** The date this goop glob was created in milliseconds from the epoch. */
   union { null, long } created = null;
 
   /**
-  The time at which this sequencer input was last updated in milliseconds from the epoch. */
+  The time at which this goop glob was last updated in milliseconds from the epoch. */
   union { null, long } updated = null;
 
-  /** A map of additional sequencer input information. */
+  /** A map of additional goop glob information. */
   map<array<string>> info = {};
 }
 

--- a/src/main/resources/avro/reads.avdl
+++ b/src/main/resources/avro/reads.avdl
@@ -124,6 +124,12 @@ record ReadGroupSet {
   /** The read group set name. */
   union { null, string } name = null;
 
+  /** The ID of the `SequencerInput` this read group set's data was generated from. */
+  union { null, string } sequencerInputId = null;
+
+  /** The ID of the `ReadGroupSet` this read group set's data was directly generated from. */
+  union { null, string } readGroupSetId = null;
+
   /** Statistical data on reads in this read group set. */
   union { null, ReadStats } stats = null;
 

--- a/src/main/resources/avro/reads.avdl
+++ b/src/main/resources/avro/reads.avdl
@@ -76,8 +76,8 @@ record ReadGroup {
   /** The read group description. */
   union { null, string } description = null;
 
-  /** The sample this read group's data was generated from. */
-  union { null, string } sampleId;
+  /** The ID of the analysis sample this read group's data was generated from. */
+  union { null, string } analysisSampleId;
 
   /** The experiment used to generate this read group. */
   union { null, Experiment } experiment;
@@ -124,10 +124,10 @@ record ReadGroupSet {
   /** The read group set name. */
   union { null, string } name = null;
 
-  /** The ID of the `AnalysisSample` this read group set's data was generated from. */
+  /** The ID of the analysis sample this read group set's data was generated from. */
   union { null, string } analysisSampleId = null;
 
-  /** The ID of the `ReadGroupSet` this read group set's data was directly generated from. */
+  /** The ID of the read group set this read group set's data was directly generated from. */
   union { null, string } readGroupSetId = null;
 
   /** Statistical data on reads in this read group set. */

--- a/src/main/resources/avro/reads.avdl
+++ b/src/main/resources/avro/reads.avdl
@@ -124,8 +124,8 @@ record ReadGroupSet {
   /** The read group set name. */
   union { null, string } name = null;
 
-  /** The ID of the `SequencerInput` this read group set's data was generated from. */
-  union { null, string } sequencerInputId = null;
+  /** The ID of the `GoopGlob` this read group set's data was generated from. */
+  union { null, string } goopGlobId = null;
 
   /** The ID of the `ReadGroupSet` this read group set's data was directly generated from. */
   union { null, string } readGroupSetId = null;

--- a/src/main/resources/avro/reads.avdl
+++ b/src/main/resources/avro/reads.avdl
@@ -124,8 +124,8 @@ record ReadGroupSet {
   /** The read group set name. */
   union { null, string } name = null;
 
-  /** The ID of the `GoopGlob` this read group set's data was generated from. */
-  union { null, string } goopGlobId = null;
+  /** The ID of the `AnalysisSample` this read group set's data was generated from. */
+  union { null, string } analysisSampleId = null;
 
   /** The ID of the `ReadGroupSet` this read group set's data was directly generated from. */
   union { null, string } readGroupSetId = null;

--- a/src/main/resources/avro/variants.avdl
+++ b/src/main/resources/avro/variants.avdl
@@ -76,8 +76,8 @@ record CallSet {
   /** The call set name. */
   union { null, string } name = null;
 
-  /** The ID of the sequencer input this call set's data was generated from. */
-  union { null, string } sequencerInputId = null;
+  /** The ID of the goop glob this call set's data was generated from. */
+  union { null, string } goopGlobId = null;
 
   /** The ID of the read group set this call set's data was directly generated from. */
   union { null, string } readGroupSetId = null;

--- a/src/main/resources/avro/variants.avdl
+++ b/src/main/resources/avro/variants.avdl
@@ -76,8 +76,8 @@ record CallSet {
   /** The call set name. */
   union { null, string } name = null;
 
-  /** The ID of the goop glob this call set's data was generated from. */
-  union { null, string } goopGlobId = null;
+  /** The ID of the analysis sample this call set's data was generated from. */
+  union { null, string } analysisSampleId = null;
 
   /** The ID of the read group set this call set's data was directly generated from. */
   union { null, string } readGroupSetId = null;

--- a/src/main/resources/avro/variants.avdl
+++ b/src/main/resources/avro/variants.avdl
@@ -65,7 +65,7 @@ record VariantSet {
 }
 
 /**
-A `CallSet` is a collection of variant calls for a particular sample.
+A `CallSet` is a collection of variant calls for a particular analysis of particular tissue.
 It belongs to a `VariantSet`. This is equivalent to one column in VCF.
 */
 record CallSet {
@@ -76,12 +76,11 @@ record CallSet {
   /** The call set name. */
   union { null, string } name = null;
 
-  /** The ID of the `SequencerInput` this call set's data was generated from. */
+  /** The ID of the sequencer input this call set's data was generated from. */
   union { null, string } sequencerInputId = null;
 
-  /** The ID of the `ReadGroupsSet` this call set's data was directly generated from. */
+  /** The ID of the read group set this call set's data was directly generated from. */
   union { null, string } readGroupSetId = null;
-  
   
   /** The ID of the variant set this call set has calls in. */
   union { null, string} variantSetId = null;

--- a/src/main/resources/avro/variants.avdl
+++ b/src/main/resources/avro/variants.avdl
@@ -76,11 +76,15 @@ record CallSet {
   /** The call set name. */
   union { null, string } name = null;
 
-  /** The sample this call set's data was generated from. */
-  union { null, string } sampleId;
+  /** The ID of the `SequencerInput` this call set's data was generated from. */
+  union { null, string } sequencerInputId = null;
 
-  /** The IDs of the variant sets this call set has calls in. */
-  array<string> variantSetIds = [];
+  /** The ID of the `ReadGroupsSet` this call set's data was directly generated from. */
+  union { null, string } readGroupSetId = null;
+  
+  
+  /** The ID of the variant set this call set has calls in. */
+  union { null, string} variantSetId = null;
 
   /** The date this call set was created in milliseconds from the epoch. */
   union { null, long } created = null;


### PR DESCRIPTION
*-1 -- this is not ready to commit; it's meant to drive discussion.*

Following up on #390, here's a sketch of the schema changes needed to add formal provenance support. It does three things:
* defines a new `SequencerInput` object, whose function is to collapse all the 'wet' provenance into a single "here's where all the bits came from" object. (I think it's roughly the same as the 'informatics sample' concept that @lh3 discusses, but I'm not sure.) The name is terrible but explicit -- the idea is that all of the work of experiment design, subject selection, tissue collection, and sample prep results in one blob of DNA that gets run through a sequencer, generating one blob of reads that we want to process as a unit.
* adds explicit derived-from pointers to the `ReadGroupSet` object
* adds explicit derived-from pointers to the `CallSet` object, and does related small cleanups to that object

The resulting formal provenance chain looks like:
```
SequencerInput ==> raw ReadGroupSet ==> aligned ReadGroupSet ==> CallSet
```
Those are all potentially one-to-many arrows. For example, while each `CallSet` comes from exactly one aligned `ReadGroupSet` and exactly one `SequencerInput`, there could be many `ReadGroupSet` and `CallSet` objects that all come from the same `SequencerInput`.

Things we'd have to resolve before committing something like this:

1. what's the right name and description for a `SequencerInput` object?
2. think through how users will create and manage `SequencerInput` objects. Different server implementors could come up with different approaches, but we need to be sure there's at least one practical answer. Options include:
  * derive the formal hierarchy from the ad hoc information found in BAM and VCF files. The Google implementation attempts to do this today by extracting sample names from files, and storing them in the `sampleId` fields, but there's no guarantee of completeness or uniqueness in the raw data
  * add support for importing manifest files of some sort, which explicitly define the set of tissue sources and how they map to the BAM and VCF files
  * build a console that lets users view/edit the provenance of their data
3. add support for filtering by provenance (e.g. add optional `sourceSequencerInputId` and `sourceReadGroupSetid` fields to the `SearchReadGroupSet` and `SearchCallSet` methods). These should be easy to define, and relatively easy to implement, but they do add work for all  server implementors. I think they're necessary for this formal provenance to be worth doing, though.
4. add methods to manage these new objects (e.g. `GetSequencerInput` and `SearchSequencerInput`)
5. MAYBE LATER: add first-class metadata fields to the `SequencerInput` object, including ways to join to external registries
6. MAYBE LATER: add more upstream provenance objects (e.g. Subject, Experiment)