### PR TITLE
Remove nullable referenceSetId in SearchReferences.

### DIFF
--- a/src/main/resources/avro/referencemethods.avdl
+++ b/src/main/resources/avro/referencemethods.avdl
@@ -94,9 +94,9 @@ as JSON.
 */
 record SearchReferencesRequest {
   /**
-  If not null, return only references which belong to this reference set.
+  The `ReferenceSet` to search.
   */
-  union { null, string } referenceSetId = null;
+  string referenceSetId;
 
   /**
   If nonempty, return references which match any of the given `md5checksums`.


### PR DESCRIPTION
This corrects an inconsistency in the API, and makes the SearchReferencesRequest symmetric with the other SearchXRequest objects. All other requests (SeachVariantSets, SearchReadGroupSets, etc) take the parent container as a mandatory argument.

This is a bugfix in my view, and should be included in the next release.