### PR TITLE
Replaced first-class object CallSet with auxiliary object CallingMethod

### DIFF
--- a/src/main/resources/avro/reads.avdl
+++ b/src/main/resources/avro/reads.avdl
@@ -77,7 +77,7 @@ record ReadGroup {
   union { null, string } description = null;
 
   /** The sample this read group's data was generated from. */
-  union { null, string } sampleId;
+  union { null, string } sampleName;
 
   /** The experiment used to generate this read group. */
   union { null, Experiment } experiment;

--- a/src/main/resources/avro/variantmethods.avdl
+++ b/src/main/resources/avro/variantmethods.avdl
@@ -70,12 +70,12 @@ record SearchVariantsRequest {
   string variantSetId;
 
   /**
-  Only return variant calls belonging to these columns.
+  Only return variant calls belonging to these samples.
   If an empty array, returns variants without any call objects.
   If null, returns all variant calls.
   TODO: rename
   */
-  union { null, array<string> } columnHandles = null;
+  union { null, array<string> } sampleNames = null;
 
   /** Required. Only return variants on this reference. */
   string referenceName;
@@ -113,8 +113,8 @@ record SearchVariantsRequest {
 record SearchVariantsResponse {
   /**
   The list of matching variants.
-  If the `columnHandle` field on the returned calls is not present, the
-  ordering of the columns from a `SearchVariantsRequest` over the parent
+  If the `sampleName` field on the returned calls is not present, the
+  ordering of the samples from a `SearchVariantsRequest` over the parent
   `VariantSet` is guaranteed to match the ordering of the calls on each
   `Variant`. The number of results will also be the same.
   */

--- a/src/main/resources/avro/variantmethods.avdl
+++ b/src/main/resources/avro/variantmethods.avdl
@@ -70,11 +70,12 @@ record SearchVariantsRequest {
   string variantSetId;
 
   /**
-  Only return variant calls which belong to call sets with these IDs.
+  Only return variant calls belonging to these columns.
   If an empty array, returns variants without any call objects.
   If null, returns all variant calls.
+  TODO: rename
   */
-  union { null, array<string> } callSetIds = null;
+  union { null, array<string> } columnHandles = null;
 
   /** Required. Only return variants on this reference. */
   string referenceName;
@@ -112,11 +113,10 @@ record SearchVariantsRequest {
 record SearchVariantsResponse {
   /**
   The list of matching variants.
-  If the `callSetId` field on the returned calls is not present,
-  the ordering of the call sets from a `SearchCallSetsRequest`
-  over the parent `VariantSet` is guaranteed to match the ordering
-  of the calls on each `Variant`. The number of results will also be
-  the same.
+  If the `columnHandle` field on the returned calls is not present, the
+  ordering of the columns from a `SearchVariantsRequest` over the parent
+  `VariantSet` is guaranteed to match the ordering of the calls on each
+  `Variant`. The number of results will also be the same.
   */
   array<org.ga4gh.models.Variant> variants = [];
 
@@ -146,69 +146,6 @@ Gets a `Variant` by ID.
 org.ga4gh.models.Variant getVariant(
   /**
   The ID of the `Variant`.
-  */
-  string id) throws GAException;
-
-/******************  /callsets/search  *********************/
-/** This request maps to the body of `POST /callsets/search` as JSON. */
-record SearchCallSetsRequest {
-  /**
-  The VariantSet to search.
-  */
-  string variantSetId;
-
-  /**
-  Only return call sets with this name (case-sensitive, exact match).
-  */
-  union { null, string } name = null;
-
-  // TODO: Add more ways to search by other metadata
-
-  /**
-  Specifies the maximum number of results to return in a single page.
-  If unspecified, a system default will be used.
-  */
-  union { null, int } pageSize = null;
-
-  /**
-  The continuation token, which is used to page through large result sets.
-  To get the next page of results, set this parameter to the value of
-  `nextPageToken` from the previous response.
-  */
-  union { null, string } pageToken = null;
-}
-
-/** This is the response from `POST /callsets/search` expressed as JSON. */
-record SearchCallSetsResponse {
-  /** The list of matching call sets. */
-  array<org.ga4gh.models.CallSet> callSets = [];
-
-  /**
-  The continuation token, which is used to page through large result sets.
-  Provide this value in a subsequent request to return the next page of
-  results. This field will be empty if there aren't any additional results.
-  */
-  union { null, string } nextPageToken = null;
-}
-
-/**
-Gets a list of `CallSet` matching the search criteria.
-
-`POST /callsets/search` must accept a JSON version of `SearchCallSetsRequest`
-as the post body and will return a JSON version of `SearchCallSetsResponse`.
-*/
-SearchCallSetsResponse searchCallSets(
-  /** This request maps to the body of `POST /callsets/search` as JSON. */
-  SearchCallSetsRequest request) throws GAException;
-
-/****************  /callsets/{id}  *******************/
-/**
-Gets a `CallSet` by ID.
-`GET /callsets/{id}` will return a JSON version of `CallSet`.
-*/
-org.ga4gh.models.CallSet getCallSet(
-  /**
-  The ID of the `CallSet`.
   */
   string id) throws GAException;
 

--- a/src/main/resources/avro/variants.avdl
+++ b/src/main/resources/avro/variants.avdl
@@ -41,6 +41,29 @@ record VariantSetMetadata {
 }
 
 /**
+Method used for variant calling
+*/
+record CallingMethod {
+  /** The variant set for which the method is used */
+  string variantSetId;
+
+  /** the sample in the variant set to which the method is applied */
+  string sampleName;
+
+  /** The date this call set was created in milliseconds from the epoch. */
+  union { null, long } created = null;
+
+  /**
+  The time at which this call set was last updated in milliseconds from the
+  epoch.
+  */
+  union ( null, long } updated = null;
+
+  /** A map of additional information on the calling method. */
+  map<array<string>> info = {};
+}
+
+/**
 `Variant` belongs to a `VariantSet`.
 `VariantSet` belongs to a `Dataset`.
 The variant set is equivalent to a VCF file.
@@ -57,12 +80,8 @@ record VariantSet {
   */
   string referenceSetId;
 
-  /**
-  Handles to the "columns" of the VariantSet, each unique at least within the
-  VariantSet.
-  TODO: rename this pending the outcome of other PRs.
-  */
-  array<string> columnHandles = [];
+  /** Samples used in this variant set */
+  array<string> sampleNames = [];
 
   /**
   The metadata associated with this variant set. This is equivalent to
@@ -82,14 +101,13 @@ the occurrence of a SNP named rs1234 in a call set with the name NA12345.
 record Call {
 
   /**
-  The handle of the column this variant call belongs to.
-  If this field is not present, the ordering of the columns from a
+  The sample this variant call belongs to.
+  If this field is not present, the ordering of the samples from a
   `SearchVariantsRequest` over this `VariantSet` is guaranteed to match the
   ordering of the calls on this `Variant`.
   The number of results will also be the same.
-  TODO: rename
   */
-  union { null, string } columnHandle = null;
+  union { null, string } sampleName = null;
 
   /**
   The genotype of this variant call.

--- a/src/main/resources/avro/variants.avdl
+++ b/src/main/resources/avro/variants.avdl
@@ -41,7 +41,7 @@ record VariantSetMetadata {
 }
 
 /**
-`Variant` and `CallSet` both belong to a `VariantSet`.
+`Variant` belongs to a `VariantSet`.
 `VariantSet` belongs to a `Dataset`.
 The variant set is equivalent to a VCF file.
 */
@@ -58,43 +58,17 @@ record VariantSet {
   string referenceSetId;
 
   /**
+  Handles to the "columns" of the VariantSet, each unique at least within the
+  VariantSet.
+  TODO: rename this pending the outcome of other PRs.
+  */
+  array<string> columnHandles = [];
+
+  /**
   The metadata associated with this variant set. This is equivalent to
   the VCF header information not already presented in first class fields.
   */
   array<VariantSetMetadata> metadata = [];
-}
-
-/**
-A `CallSet` is a collection of variant calls for a particular sample.
-It belongs to a `VariantSet`. This is equivalent to one column in VCF.
-*/
-record CallSet {
-
-  /** The call set ID. */
-  string id;
-
-  /** The call set name. */
-  union { null, string } name = null;
-
-  /** The sample this call set's data was generated from. */
-  union { null, string } sampleId;
-
-  /** The IDs of the variant sets this call set has calls in. */
-  array<string> variantSetIds = [];
-
-  /** The date this call set was created in milliseconds from the epoch. */
-  union { null, long } created = null;
-
-  /**
-  The time at which this call set was last updated in
-  milliseconds from the epoch.
-  */
-  union { null, long } updated = null;
-
-  /**
-  A map of additional call set information.
-  */
-  map<array<string>> info = {};
 }
 
 /**
@@ -108,23 +82,14 @@ the occurrence of a SNP named rs1234 in a call set with the name NA12345.
 record Call {
 
   /**
-  The name of the call set this variant call belongs to.
-  If this field is not present, the ordering of the call sets from a
-  `SearchCallSetsRequest` over this `VariantSet` is guaranteed to match
-  the ordering of the calls on this `Variant`.
+  The handle of the column this variant call belongs to.
+  If this field is not present, the ordering of the columns from a
+  `SearchVariantsRequest` over this `VariantSet` is guaranteed to match the
+  ordering of the calls on this `Variant`.
   The number of results will also be the same.
+  TODO: rename
   */
-  union { null, string } callSetName = null;
-
-  /**
-  The ID of the call set this variant call belongs to.
-
-  If this field is not present, the ordering of the call sets from a
-  `SearchCallSetsRequest` over this `VariantSet` is guaranteed to match
-  the ordering of the calls on this `Variant`.
-  The number of results will also be the same.
-  */
-  union { null, string} callSetId = null;
+  union { null, string } columnHandle = null;
 
   /**
   The genotype of this variant call.


### PR DESCRIPTION
This PR is based on @mlin's PR #395 that removes the first-class object CallSet. Different from #395, this PR adds CallingMethod in response to @dglazer's request to record the variant calling process. More importantly, it gives @mlin's columnHandler a specific meaning – conceptual "sample" used in analysis – but without introducing an explicit AnalysisSample object. The sample relationship between objects are kept track by ReadGroup::sampleName, VariantSet::sampleNames[], Call::sampleName and CallingMethod::sampleName. In this commit, first-class objects are:
```java
// in metadata.avdl
record Dataset {}
// in reads.avdl
record ReadGroup { string datasetId; string sampleName; }
record ReadGroupSet { string datasetId; array<ReadGroup> readGroups; }
record ReadAlignment { string readGroupId; }
// in variants.avdl
record VariantSet { string datasetId; array<string> sampleNames; }
record Call {} // embedded in Variant only
record Variant { string variantSetId; array<Call> calls; }
```
A natural evolution of this commit is to add an AnalysisSample object as in #383 and #391, but without it, the schema still works as we are not keeping sample phenotypes in our schema at present. On a side note, it may be worth rethinking about the relationship between sampleName, ReadGroup and ReadGroupSet, but that is a separate PR.