### PR TITLE
Adds missing name field to VariantSet and ReferenceSet

### DIFF
--- a/src/main/resources/avro/references.avdl
+++ b/src/main/resources/avro/references.avdl
@@ -80,6 +80,9 @@ record ReferenceSet {
   /** The reference set ID. Unique in the repository. */
   string id;
 
+  /** The reference set name. */
+  union { null, string } name = null;
+
   /**
   Order-independent MD5 checksum which identifies this `ReferenceSet`.
 

--- a/src/main/resources/avro/variants.avdl
+++ b/src/main/resources/avro/variants.avdl
@@ -49,6 +49,9 @@ record VariantSet {
   /** The variant set ID. */
   string id;
 
+  /** The variant set name. */
+  union { null, string } name = null;
+
   /** The ID of the dataset this variant set belongs to. */
   string datasetId;
 


### PR DESCRIPTION
This PR adds a ``name`` field to VariantSet and ReferenceSet. This makes them consistent with all the other container types (Dataset, ReadGroupSet and ReadGroup). The name field is a user-specified, human readable identifier.

This is the last proposed change before the baseline milestone. It should be uncontroversial since

1. it's implementing the growing consensus on the need for names;
2. it has no backwards compatibility implications as it's just adding a new field.

It would be good if we could either get a quick consensus on this and merge it, or definitively drop it as part of the baseline. 