### PR TITLE
Update metadata.avdl

### DIFF
--- a/src/main/resources/avro/metadata.avdl
+++ b/src/main/resources/avro/metadata.avdl
@@ -2,8 +2,6 @@
 
 /**
 This protocol defines metadata used in the other GA4GH protocols.
-`FIXME: Remove recordCreateTime and recordUpdateTime fields. Timestamps should not be part of these records, because they will
-not be updated (they can be deleted or stored under a new ID if information changes)`
 */
 
 protocol Metadata {


### PR DESCRIPTION
Removal of timestamp FIXME

Though we can discuss if timestamps should be part of the schema (IMO) or be left to the implementations, the argumentation *different version = different object* is misleading. Especially for "wet" objects like ```Biosample```, the most important point is to identify physical identity, even with changing descriptions. This is best being served with a constant ID, and (optional) modification times (or an object hash with time identifier) to get the latest version.