### PR TITLE
VariantAnnotationSet change & Allele location update

### DIFF
--- a/src/main/resources/avro/alleleAnnotationmethods.avdl
+++ b/src/main/resources/avro/alleleAnnotationmethods.avdl
@@ -1,7 +1,7 @@
 @namespace("org.ga4gh.methods")
 protocol AlleleAnnotationMethods {
 
-/*This protocol defines methods use to mine pre-calculated annotation sets.*/
+/*This protocol defines methods use to mine pre-calculated variant allele annotations.*/
 
 import idl "methods.avdl";
 import idl "variants.avdl";
@@ -18,15 +18,15 @@ features. Where a region is supplied annotation of all alleles vs all features i
 is returned. Where a set of features is supplied, only annotations against these features
 (matching on featuretype and id) are returned and other overlapping features are ignored.
 
-annotationsets/search returns information on reference data and software versions used in
+variantannotationsets/search returns information on reference data and software versions used in
 calculating the annotation. It is essential this information is exhaustive.
 */
 
 /******************  /variantannotations/search  *********************/
 /** This request maps to the body of `POST /variantannotations/search` as JSON. */
 record SearchVariantAnnotationsRequest {
-  /** Required. The ID of the annotation set to search over. */
-  string annotationSetId;
+  /** Required. The ID of the variant annotation set to search over. */
+  string variantAnnotationSetId;
 
   /**
   Only return annotation for variants which have exactly this name
@@ -201,12 +201,12 @@ SearchAlleleAnnotationsResponse searchAlleleAnnotations(
     */
     SearchAlleleAnnotationsRequest request) throws GAException;
 
-/****************** /annotationsets/search *********************/
-/** This request maps to the body of `POST /annotationsets/search` as JSON. */
-record SearchAnnotationSetsRequest {
+/****************** /variantannotationsets/search *********************/
+/** This request maps to the body of `POST /variantannotationsets/search` as JSON. */
+record SearchVariantAnnotationSetsRequest {
 
   /**
-  If non empty, will restrict the query to annotation sets within the
+  If non empty, will restrict the query to variant annotation sets within the
   given dataset.
   */
   string datasetId;
@@ -226,11 +226,11 @@ record SearchAnnotationSetsRequest {
 
 }
 
-/** This is the response from `POST /annotationsets/search` expressed as JSON. */
-record SearchAnnotationSetsResponse {
+/** This is the response from `POST /variantannotationsets/search` expressed as JSON. */
+record SearchVariantAnnotationSetsResponse {
 
-  /** The list of matching annotation sets. */
-  array<org.ga4gh.models.AnnotationSet> annotationSets = [];
+  /** The list of matching variant annotation sets. */
+  array<org.ga4gh.models.VariantAnnotationSet> variantAnnotationSets = [];
 
   /**
   The continuation token, which is used to page through large result sets.
@@ -242,23 +242,23 @@ record SearchAnnotationSetsResponse {
 }
 
 /**
-Returns a list of available annotation sets
-`POST /annotationsets/search` must accept a JSON version of
-`SearchAnnotationSetsRequest` as the post body and will return a JSON version
-of `SearchAnnotationSetsResponse`.
+Returns a list of available variant annotation sets
+`POST /variantannotationsets/search` must accept a JSON version of
+`SearchVariantAnnotationSetsRequest` as the post body and will return a JSON version
+of `SearchVariantAnnotationSetsResponse`.
 */
-SearchAnnotationSetsResponse searchAnnotationSets(
-  /** This request maps to the body of `POST /annotationsets/search` as JSON. */
-  SearchAnnotationSetsRequest request) throws GAException;
+SearchVariantAnnotationSetsResponse searchVariantAnnotationSets(
+  /** This request maps to the body of `POST /variantannotationsets/search` as JSON. */
+  SearchVariantAnnotationSetsRequest request) throws GAException;
 
-/**************** /annotationsets/{id} *******************/
+/**************** /variantannotationsets/{id} *******************/
 /**
-Gets an `AnnotationSet` by ID.
-`GET /annotationsets/{id}` will return a JSON version of `AnnotationSet`.
+Gets an `VariantAnnotationSet` by ID.
+`GET /variantannotationsets/{id}` will return a JSON version of `VariantAnnotationSet`.
 */
-org.ga4gh.models.AnnotationSet getAnnotationSet(
+org.ga4gh.models.VariantAnnotationSet getVariantAnnotationSet(
   /**
-  The ID of the `AnnotationSet`.
+  The ID of the `VariantAnnotationSet`.
   */
   string id) throws GAException;
 

--- a/src/main/resources/avro/alleleAnnotationmethods.avdl
+++ b/src/main/resources/avro/alleleAnnotationmethods.avdl
@@ -127,6 +127,12 @@ record SearchVariantAnnotationSetsRequest {
   string datasetId;
 
   /**
+  If non empty, will restrict the query to variant annotation sets within the
+  given variant set. This takes precedence over any dataset id supplied.
+  */
+  string variantSetId;
+
+  /**
   Specifies the maximum number of results to return in a single page.
   If unspecified, a system default will be used.
   */

--- a/src/main/resources/avro/alleleAnnotationmethods.avdl
+++ b/src/main/resources/avro/alleleAnnotationmethods.avdl
@@ -1,7 +1,10 @@
 @namespace("org.ga4gh.methods")
 protocol AlleleAnnotationMethods {
 
-/*This protocol defines methods use to mine pre-calculated variant allele annotations.*/
+/*
+This protocol defines methods use to mine pre-calculated variant allele
+annotations.
+*/
 
 import idl "methods.avdl";
 import idl "variants.avdl";
@@ -10,19 +13,24 @@ import idl "sequenceAnnotations.avdl";
 import idl "ontologies.avdl";
 
 /*
-variantannotations/search returns annotation for the alleles of classic/linear variants
+variantannotations/search returns annotation for the alleles of Variants
 
-This allows the mining of allele-specific annotations by either a region or a set of genomic
-features. Where a region is supplied annotation of all alleles vs all features in the region
-is returned. Where a set of features is supplied, only annotations against these features
-(matching on featuretype and id) are returned and other overlapping features are ignored.
+This allows the mining of allele-specific annotations on a VariantSet by
+either a region or by a set of genomic features. Where a region is supplied
+annotation of all alleles vs all features in the region is returned. Where a
+set of features is supplied, only annotations against these features (matching
+on featuretype and id) are returned and other overlapping features are ignored.
 
-variantannotationsets/search returns information on reference data and software versions used in
-calculating the annotation. It is essential this information is exhaustive.
+variantannotationsets/search returns information on the input to the
+annotation. This will be a VariantSet and the reference data and software
+versions used in calculating the annotation.
+It is essential this information is exhaustive.
 */
 
 /******************  /variantannotations/search  *********************/
-/** This request maps to the body of `POST /variantannotations/search` as JSON. */
+/** 
+This request maps to the body of `POST /variantannotations/search` as JSON
+*/
 record SearchVariantAnnotationsRequest {
   /** Required. The ID of the variant annotation set to search over. */
   string variantAnnotationSetId;
@@ -34,15 +42,15 @@ record SearchVariantAnnotationsRequest {
   union { null, string } name = null;
 
   /**
-  Only return variants with reference alleles on the reference with this name.
-  One of this field or `referenceId` or `features` is required.
+  Only return variants with reference alleles on the reference with this
+  name. One of this field or `referenceId` or `features` is required.
   (case-sensitive, exact match)
   */
   union { null, string } referenceName = null;
 
   /**
-  Only return variants with reference alleles on the reference with this ID. One
-  of this field or `referenceName` or `features` is required.
+  Only return variants with reference alleles on the reference with this
+  ID. One of this field or `referenceName` or `features` is required.
   */
   union { null, string } referenceId = null;
 
@@ -66,8 +74,8 @@ record SearchVariantAnnotationsRequest {
   /**
   Only return variant annotations for any of these features
   Features may include specific transcripts, genes or regulatory elements
-  This or a location (referenceName/referenceId plus optional start and end) 
-  must be supplied. 
+  This or a location (referenceName/referenceId plus optional start and end)
+  must be supplied.
   If null, return all variant annotations in specified window.
   */
   union { null, array<string> } feature_ids;
@@ -92,7 +100,9 @@ record SearchVariantAnnotationsRequest {
   union { null, string } pageToken = null;
 }
 
-/** This is the response from `POST /variantannotations/search` expressed as JSON. */
+/**
+This is the response from `POST /variantannotations/search` expressed as JSON.
+*/
 record SearchVariantAnnotationsResponse {
   /**
   The list of matching variant annotations.
@@ -110,14 +120,19 @@ record SearchVariantAnnotationsResponse {
 /**
 Gets a list of `VariantAnnotations` matching the search criteria.
 
-`POST /variantannotations/search` must accept a JSON version of `SearchVariantAnnotationsRequest`
-as the post body and will return a JSON version of `SearchVariantAnnotationsResponse`.
+`POST /variantannotations/search` must accept a JSON version of
+`SearchVariantAnnotationsRequest` as the post body and will return a
+JSON version of `SearchVariantAnnotationsResponse`.
 */
 SearchVariantAnnotationsResponse searchVariantAnnotations(
-  /** This request maps to the body of `POST /variantannotations/search` as JSON. */
+  /**
+  This request maps to the body of `POST /variantannotations/search` as JSON.
+  */
   SearchVariantAnnotationsRequest request) throws GAException;
 
-/** This request maps to the body of `POST /variantannotationsets/search` as JSON. */
+/**
+This request maps to the body of `POST /variantannotationsets/search` as JSON
+*/
 record SearchVariantAnnotationSetsRequest {
 
   /**
@@ -147,7 +162,10 @@ record SearchVariantAnnotationSetsRequest {
 
 }
 
-/** This is the response from `POST /variantannotationsets/search` expressed as JSON. */
+/**
+This is the response from `POST /variantannotationsets/search` expressed
+as JSON.
+*/
 record SearchVariantAnnotationSetsResponse {
 
   /** The list of matching variant annotation sets. */
@@ -165,17 +183,20 @@ record SearchVariantAnnotationSetsResponse {
 /**
 Returns a list of available variant annotation sets
 `POST /variantannotationsets/search` must accept a JSON version of
-`SearchVariantAnnotationSetsRequest` as the post body and will return a JSON version
-of `SearchVariantAnnotationSetsResponse`.
+`SearchVariantAnnotationSetsRequest` as the post body and will return a JSON
+version of `SearchVariantAnnotationSetsResponse`.
 */
 SearchVariantAnnotationSetsResponse searchVariantAnnotationSets(
-  /** This request maps to the body of `POST /variantannotationsets/search` as JSON. */
+  /**
+  This request maps to the body of `POST /variantannotationsets/search` as JSON
+  */
   SearchVariantAnnotationSetsRequest request) throws GAException;
 
 /**************** /variantannotationsets/{id} *******************/
 /**
 Gets an `VariantAnnotationSet` by ID.
-`GET /variantannotationsets/{id}` will return a JSON version of `VariantAnnotationSet`.
+`GET /variantannotationsets/{id}` will return a JSON version of
+`VariantAnnotationSet`.
 */
 org.ga4gh.models.VariantAnnotationSet getVariantAnnotationSet(
   /**

--- a/src/main/resources/avro/alleleAnnotationmethods.avdl
+++ b/src/main/resources/avro/alleleAnnotationmethods.avdl
@@ -11,9 +11,8 @@ import idl "ontologies.avdl";
 
 /*
 variantannotations/search returns annotation for the alleles of classic/linear variants
-alleleannotations/search returns annotation for graph alleles
 
-Both allow the mining of allele-specific annotations by either a region or a set of genomic
+This allows the mining of allele-specific annotations by either a region or a set of genomic
 features. Where a region is supplied annotation of all alleles vs all features in the region
 is returned. Where a set of features is supplied, only annotations against these features
 (matching on featuretype and id) are returned and other overlapping features are ignored.
@@ -118,90 +117,6 @@ SearchVariantAnnotationsResponse searchVariantAnnotations(
   /** This request maps to the body of `POST /variantannotations/search` as JSON. */
   SearchVariantAnnotationsRequest request) throws GAException;
 
-/******************  /alleleannotations/search  *********************/
-/** This request maps to the body of `POST /alleleannotations/search` as JSON. */
-record SearchAlleleAnnotationsRequest {
-  /** Required. The ID of the annotation set to search over. */
-  string annotationSetId;
-
-  /**
-  This or features is required. Only return annotations for `Allele`s on the
-  sequence with this ID.
-  */
-  string sequenceId;
-
-  /**
-  Required if sequenceId supplied. The beginning of the window (0-based,
-  inclusive) for which overlapping alleles should be returned.
-  Genomic positions are non-negative integers less than segment length.
-  Requests spanning the join of circular genomes are represented as
-  two requests one on each side of the join (position 0).
-  */
-  long start;
-
-  /**
-  Required if sequenceId supplied. The end of the window (0-based, exclusive)
-  for which overlapping alleles should be returned.
-  */
-  long end;
-
-  /**
-  Only return allele annotations for any of these features
-  Features may include specific transcripts, genes or regulatory elements
-  This or a location (referenceName/referenceId plus start and end) must be supplied
-  If null, return all allele annotations in specified window.
-  */
-  union { null, array<org.ga4gh.models.Feature> } features;
-
-  /**
-  Only return allele annotations including these effects (SO terms)
-  If null, return all allele annotations.
-  */
-  union { null, array<org.ga4gh.models.OntologyTerm> } effects = null;
-
-  /**
-  Specifies the maximum number of results to return in a single page.
-  If unspecified, a system default will be used.
-  */
-  union { null, int } pageSize = null;
-
-  /**
-  The continuation token, which is used to page through large result sets.
-  To get the next page of results, set this parameter to the value of
-  `nextPageToken` from the previous response.
-  */
-  union { null, string } pageToken = null;
-}
-
-/** This is the response from `POST /alleleannotations/search` expressed as JSON. */
-record SearchAlleleAnnotationsResponse {
-  /**
-  The list of matching alleles. An `Allele` should be returned if a `Segment`
-  in its `Path` overlaps with the specified range.
-  */
-  array<org.ga4gh.models.AlleleAnnotation> alleleAnnotations = [];
-
-  /**
-  The continuation token, which is used to page through large result sets.
-  Provide this value in a subsequent request to return the next page of
-  results. This field will be empty if there aren't any additional results.
-  */
-  union { null, string } nextPageToken = null;
-}
-
-/**
-Gets a list of `AlleleAnnotation`s matching the search criteria.
-
-`POST /alleleannotations/search` must accept a JSON version of `SearchAlleleAnnotationsRequest` as
-the post body and will return a JSON version of `SearchAlleleAnnotationsResponse`.
-*/
-SearchAlleleAnnotationsResponse searchAlleleAnnotations(
-    /**
-    This request maps to the body of `POST /alleleannotations/search` as JSON.
-    */
-    SearchAlleleAnnotationsRequest request) throws GAException;
-
-/****************** /variantannotationsets/search *********************/
 /** This request maps to the body of `POST /variantannotationsets/search` as JSON. */
 record SearchVariantAnnotationSetsRequest {
 

--- a/src/main/resources/avro/alleleAnnotations.avdl
+++ b/src/main/resources/avro/alleleAnnotations.avdl
@@ -61,7 +61,7 @@ record AlleleLocation {
   int overlapStart ;
 
   /** Relative end position of the allele in this coordinate system  */
-  int overlapEnd ;
+  union { null, int } overlapEnd = null;
 
   /** Reference sequence in feature (this should be the codon at CDS level) */
   union { null, string } referenceSequence = null;

--- a/src/main/resources/avro/alleleAnnotations.avdl
+++ b/src/main/resources/avro/alleleAnnotations.avdl
@@ -16,16 +16,14 @@ import idl "variants.avdl";
 import idl "ontologies.avdl";
 
 /*
-This protocol currently attempts to support linear variants and graph alleles by providing
-two grouping records (VariantAnnotation and AlleleAnnotation) which have a similar structure
-of attributes and sub-records.
+
+The VariantAnnotation record groups different types of annotation records by variant.
 
 The TranscriptEffect sub record holds information on the effect of a specific allele on a
 specific transcript.
 As Variants may overlap multiple transcripts, they may have multiple TranscriptEffect records.
 Variants with multiple alternate alleles will have multiple TranscriptEffect records per
 transcript. (2 alternate alleles x 3 transcripts = 6 TranscriptEffect records)
-As graph Alleles may overlap multiple transcripts, they may have multiple TranscriptEffect records.
 
 VariantAnnotation records belong to VariantAnnotationSets. VariantAnnotationSets contain
 information on reference data and software versions used in calculating the annotation. It is
@@ -180,41 +178,6 @@ record VariantAnnotation {
   /**
   The IDs of other variants which are co-located with this variant.
   these can use used to look up disease associations, ClinVar statuses,
-  allele frequencies in reference panels, etc
-  */
-  array<string> coLocatedVariants =[];
-
-  /** Additional annotation data in key-value pairs. */
-  map<array<string>> info = {};
-}
-
-/**
-An `AlleleAnnotation` record represents the result of comparing a allele
-to a set of reference data.
-*/
-record AlleleAnnotation {
-
-  /** The ID of this AlleleAnnotation. */
-  string id;
-
-  /** The allele ID. */
-  string alleleId;
-
-  /** The ID of the annotation set this record belongs to. */
-  string annotationSetId;
-
-  /** The date this allele annotation was created in milliseconds from the epoch. */
-  union { null, long } created = null;
-
-  /**
-  The transcript effect annotation for this allele. Each one represents
-  the predicted effect of the allele on a single transcript.
-  */
-  array<TranscriptEffect> transcriptEffects = [];
-
-  /**
-  The IDs of other variants which are co-located with this allele.
-  these can use used to look up disease associations, ClinVar statuses
   allele frequencies in reference panels, etc
   */
   array<string> coLocatedVariants =[];

--- a/src/main/resources/avro/alleleAnnotations.avdl
+++ b/src/main/resources/avro/alleleAnnotations.avdl
@@ -84,20 +84,21 @@ enum Impact {
 }
 
 /**
-A VariantAnnotationSet record groups VariantAnnotation records. It holds 
-information describing the software and reference data used in the annotation.
+A VariantAnnotationSet record groups VariantAnnotation records. It is derived
+from a VariantSet and holds information describing the software and reference
+data used in the annotation.
 */
 record VariantAnnotationSet {
 
   /** The ID of the variant annotation set record */
   string id;
 
-  /** The ID of the dataset to which this annotation set belongs */
-  string datasetId;
+  /** The ID of the variant set to which this annotation set belongs */
+  string variantSetId;
 
   /**
   Analysis details. It is essential to supply versions for all software and
-  reference datasets used.
+  reference data used.
   */
   Analysis analysis;
 }

--- a/src/main/resources/avro/alleleAnnotations.avdl
+++ b/src/main/resources/avro/alleleAnnotations.avdl
@@ -27,7 +27,7 @@ Variants with multiple alternate alleles will have multiple TranscriptEffect rec
 transcript. (2 alternate alleles x 3 transcripts = 6 TranscriptEffect records)
 As graph Alleles may overlap multiple transcripts, they may have multiple TranscriptEffect records.
 
-VariantAnnotation and AlleleAnnotation records belong to AnnotationSets. AnnotationSets contain
+VariantAnnotation records belong to VariantAnnotationSets. VariantAnnotationSets contain
 information on reference data and software versions used in calculating the annotation. It is
 essential this information is exhaustive.
 
@@ -86,12 +86,12 @@ enum Impact {
 }
 
 /**
-An annotation set record groups VariantAnnotation and/or AlleleAnnotation records. It holds
+A VariantAnnotationSet record groups VariantAnnotation records. It holds 
 information describing the software and reference data used in the annotation.
 */
-record AnnotationSet {
+record VariantAnnotationSet {
 
-  /** The ID of the annotation set record */
+  /** The ID of the variant annotation set record */
   string id;
 
   /** The ID of the dataset to which this annotation set belongs */
@@ -165,8 +165,8 @@ record VariantAnnotation {
   /** The variant ID. */
   string variantId;
 
-  /** The ID of the annotation set this record belongs to. */
-  string annotationSetId;
+  /** The ID of the variant annotation set this record belongs to. */
+  string variantAnnotationSetId;
 
   /** The date this annotation was created in milliseconds from the epoch. */
   union { null, long } created = null;

--- a/src/main/resources/avro/alleleAnnotations.avdl
+++ b/src/main/resources/avro/alleleAnnotations.avdl
@@ -2,9 +2,6 @@
 
 /**
 This protocol defines types used by the GA4GH Allele Annotation API.
-
-Annotation can be applied to the alternate alleles of classic variants
-or to Alleles
 */
 
 protocol AlleleAnnotations{
@@ -17,23 +14,28 @@ import idl "ontologies.avdl";
 
 /*
 
-The VariantAnnotation record groups different types of annotation records by variant.
+The VariantAnnotation record groups different types of annotation records by
+Variant.
 
-The TranscriptEffect sub record holds information on the effect of a specific allele on a
-specific transcript.
-As Variants may overlap multiple transcripts, they may have multiple TranscriptEffect records.
-Variants with multiple alternate alleles will have multiple TranscriptEffect records per
-transcript. (2 alternate alleles x 3 transcripts = 6 TranscriptEffect records)
+The TranscriptEffect sub record holds information on the effect of a specific
+allele on a specific transcript.
+As Variants may overlap multiple transcripts, they may have multiple
+TranscriptEffect records. Variants with multiple alternate alleles will have
+multiple TranscriptEffect records per transcript.
+(2 alternate alleles x 3 transcripts = 6 TranscriptEffect records)
 
-VariantAnnotation records belong to VariantAnnotationSets. VariantAnnotationSets contain
-information on reference data and software versions used in calculating the annotation. It is
-essential this information is exhaustive.
+VariantAnnotation records belong to VariantAnnotationSets.
+VariantAnnotationSets are created by comparing a number of Variants from a
+VariantSet to a specific set of reference data using specific software tools.
+A VariantAnnotationSet contains information on reference data and software
+versions used in calculating the annotation; it is essential this information
+is exhaustive.
 
 */
 
 /**
-An AnalysisResult record holds the output of a prediction package such as SIFT on a
-specific allele/transcript combination
+An AnalysisResult record holds the output of a prediction package such
+as SIFT on a specific allele.
 */
 record AnalysisResult {
 
@@ -119,8 +121,8 @@ record TranscriptEffect {
   */
   string featureId;
 
-  /** Alternate allele - a variant may have more than one alternate allele, each of which
-  will have distinct annotation. This is not be needed for the graph Allele model
+  /** Alternate allele - a variant may have more than one alternate allele,
+  each of which will have distinct annotation.
   */
   union { null, string} alternateBases = null;
 
@@ -148,7 +150,7 @@ record TranscriptEffect {
   /** Change relative to protein  */
   union { null, AlleleLocation} proteinLocation = null;
 
-  /** Output from prediction packages such as Sift */
+  /** Output from prediction packages such as SIFT */
   array<AnalysisResult> analysisResults;
 }
 


### PR DESCRIPTION
Updates following VariantAnnotation call on 20/10/2015 and further discussion in issues #439 and #441. 

Graph Allele support is also removed awaiting stability in the underlying Allele records.