### PR TITLE
Update instructions for documentation generation

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -106,5 +106,5 @@ Assuming your working directory is the base "`schemas`" directory, do this:
 $ mvn package
 ```
 
-The documentation you generate will reside in `tools/sphinx/_build/`.  To view it, open the file
-`tools/sphinx/_build/index.html` in a browser.
+The documentation you generate will reside in `target/generated-docs/merged/html`.  To view it, open the file
+`target/generated-docs/merged/html/index.html` in a browser.

--- a/README.md
+++ b/README.md
@@ -3,6 +3,8 @@
 
 # Schemas for the Data Working Group
 
+[![Build Status](https://travis-ci.org/ga4gh/schemas.svg?branch=master)](https://travis-ci.org/ga4gh/schemas)
+[![Docs](https://readthedocs.org/projects/ga4gh-schemas/badge/)](http://ga4gh-schemas.readthedocs.org)
 
 The [Global Alliance for Genomics and Health][ga4gh] is an international
 coalition, formed to enable the sharing of genomic and clinical data.
@@ -64,10 +66,9 @@ heavily with members of most other task teams and working groups.
 
 [MTT Wiki](https://github.com/ga4gh/metadata-team/wiki)
 
+## How to build
 
-## Build Status
-
-[![Build Status](https://travis-ci.org/ga4gh/schemas.svg?branch=master)](https://travis-ci.org/ga4gh/schemas)
+See [INSTALL.md](INSTALL.md) for instructions on how to build the schemas and their documentation.
 
 ## How to contribute changes
 

--- a/doc/Makefile
+++ b/doc/Makefile
@@ -1,6 +1,11 @@
 # Makefile for Sphinx documentation
 #
 
+# DO NOT MAKE WITH THIS FILE MANUALLY. IT WILL NOT WORK.
+
+# Instead, run "mvn package" in the top-level directory. Only Maven knows how to
+# invoke this file properly.
+
 # You can set these variables from the command line.
 SPHINXOPTS    =
 SPHINXBUILD   = sphinx-build
@@ -54,17 +59,17 @@ clean:
 html:
 	$(SPHINXBUILD) -b html $(ALLSPHINXOPTS) $(BUILDDIR)/html
 	@echo
-	@echo "Build finished. The HTML pages are in $(BUILDDIR)/html."
+	@echo "Build finished."
 
 dirhtml:
 	$(SPHINXBUILD) -b dirhtml $(ALLSPHINXOPTS) $(BUILDDIR)/dirhtml
 	@echo
-	@echo "Build finished. The HTML pages are in $(BUILDDIR)/dirhtml."
+	@echo "Build finished."
 
 singlehtml:
 	$(SPHINXBUILD) -b singlehtml $(ALLSPHINXOPTS) $(BUILDDIR)/singlehtml
 	@echo
-	@echo "Build finished. The HTML page is in $(BUILDDIR)/singlehtml."
+	@echo "Build finished."
 
 pickle:
 	$(SPHINXBUILD) -b pickle $(ALLSPHINXOPTS) $(BUILDDIR)/pickle
@@ -79,114 +84,95 @@ json:
 htmlhelp:
 	$(SPHINXBUILD) -b htmlhelp $(ALLSPHINXOPTS) $(BUILDDIR)/htmlhelp
 	@echo
-	@echo "Build finished; now you can run HTML Help Workshop with the" \
-	      ".hhp project file in $(BUILDDIR)/htmlhelp."
+	@echo "Build finished."
 
 qthelp:
 	$(SPHINXBUILD) -b qthelp $(ALLSPHINXOPTS) $(BUILDDIR)/qthelp
 	@echo
-	@echo "Build finished; now you can run "qcollectiongenerator" with the" \
-	      ".qhcp project file in $(BUILDDIR)/qthelp, like this:"
-	@echo "# qcollectiongenerator $(BUILDDIR)/qthelp/ga4ghschemas.qhcp"
-	@echo "To view the help file:"
-	@echo "# assistant -collectionFile $(BUILDDIR)/qthelp/ga4ghschemas.qhc"
+	@echo "Build finished."
 
 applehelp:
 	$(SPHINXBUILD) -b applehelp $(ALLSPHINXOPTS) $(BUILDDIR)/applehelp
 	@echo
-	@echo "Build finished. The help book is in $(BUILDDIR)/applehelp."
-	@echo "N.B. You won't be able to view it unless you put it in" \
-	      "~/Library/Documentation/Help or install it in your application" \
-	      "bundle."
+	@echo "Build finished."
 
 devhelp:
 	$(SPHINXBUILD) -b devhelp $(ALLSPHINXOPTS) $(BUILDDIR)/devhelp
 	@echo
 	@echo "Build finished."
-	@echo "To view the help file:"
-	@echo "# mkdir -p $$HOME/.local/share/devhelp/ga4ghschemas"
-	@echo "# ln -s $(BUILDDIR)/devhelp $$HOME/.local/share/devhelp/ga4ghschemas"
-	@echo "# devhelp"
 
 epub:
 	$(SPHINXBUILD) -b epub $(ALLSPHINXOPTS) $(BUILDDIR)/epub
 	@echo
-	@echo "Build finished. The epub file is in $(BUILDDIR)/epub."
+	@echo "Build finished."
 
 latex:
 	$(SPHINXBUILD) -b latex $(ALLSPHINXOPTS) $(BUILDDIR)/latex
 	@echo
-	@echo "Build finished; the LaTeX files are in $(BUILDDIR)/latex."
-	@echo "Run \`make' in that directory to run these through (pdf)latex" \
-	      "(use \`make latexpdf' here to do that automatically)."
+	@echo "Build finished."
 
 latexpdf:
 	$(SPHINXBUILD) -b latex $(ALLSPHINXOPTS) $(BUILDDIR)/latex
 	@echo "Running LaTeX files through pdflatex..."
 	$(MAKE) -C $(BUILDDIR)/latex all-pdf
-	@echo "pdflatex finished; the PDF files are in $(BUILDDIR)/latex."
+	@echo "pdflatex finished."
 
 latexpdfja:
 	$(SPHINXBUILD) -b latex $(ALLSPHINXOPTS) $(BUILDDIR)/latex
 	@echo "Running LaTeX files through platex and dvipdfmx..."
 	$(MAKE) -C $(BUILDDIR)/latex all-pdf-ja
-	@echo "pdflatex finished; the PDF files are in $(BUILDDIR)/latex."
+	@echo "pdflatex finished."
 
 text:
 	$(SPHINXBUILD) -b text $(ALLSPHINXOPTS) $(BUILDDIR)/text
 	@echo
-	@echo "Build finished. The text files are in $(BUILDDIR)/text."
+	@echo "Build finished."
 
 man:
 	$(SPHINXBUILD) -b man $(ALLSPHINXOPTS) $(BUILDDIR)/man
 	@echo
-	@echo "Build finished. The manual pages are in $(BUILDDIR)/man."
+	@echo "Build finished."
 
 texinfo:
 	$(SPHINXBUILD) -b texinfo $(ALLSPHINXOPTS) $(BUILDDIR)/texinfo
 	@echo
-	@echo "Build finished. The Texinfo files are in $(BUILDDIR)/texinfo."
-	@echo "Run \`make' in that directory to run these through makeinfo" \
-	      "(use \`make info' here to do that automatically)."
+	@echo "Build finished."
 
 info:
 	$(SPHINXBUILD) -b texinfo $(ALLSPHINXOPTS) $(BUILDDIR)/texinfo
 	@echo "Running Texinfo files through makeinfo..."
 	make -C $(BUILDDIR)/texinfo info
-	@echo "makeinfo finished; the Info files are in $(BUILDDIR)/texinfo."
+	@echo "makeinfo finished."
 
 gettext:
 	$(SPHINXBUILD) -b gettext $(I18NSPHINXOPTS) $(BUILDDIR)/locale
 	@echo
-	@echo "Build finished. The message catalogs are in $(BUILDDIR)/locale."
+	@echo "Build finished."
 
 changes:
 	$(SPHINXBUILD) -b changes $(ALLSPHINXOPTS) $(BUILDDIR)/changes
 	@echo
-	@echo "The overview file is in $(BUILDDIR)/changes."
+	@echo "Build finished."
 
 linkcheck:
 	$(SPHINXBUILD) -b linkcheck $(ALLSPHINXOPTS) $(BUILDDIR)/linkcheck
 	@echo
-	@echo "Link check complete; look for any errors in the above output " \
-	      "or in $(BUILDDIR)/linkcheck/output.txt."
+	@echo "Link check complete."
 
 doctest:
 	$(SPHINXBUILD) -b doctest $(ALLSPHINXOPTS) $(BUILDDIR)/doctest
-	@echo "Testing of doctests in the sources finished, look at the " \
-	      "results in $(BUILDDIR)/doctest/output.txt."
+	@echo "Testing of doctests in the sources finished."
 
 coverage:
 	$(SPHINXBUILD) -b coverage $(ALLSPHINXOPTS) $(BUILDDIR)/coverage
-	@echo "Testing of coverage in the sources finished, look at the " \
-	      "results in $(BUILDDIR)/coverage/python.txt."
+	@echo "Testing of coverage in the sources finished."
 
 xml:
 	$(SPHINXBUILD) -b xml $(ALLSPHINXOPTS) $(BUILDDIR)/xml
 	@echo
-	@echo "Build finished. The XML files are in $(BUILDDIR)/xml."
+	@echo "Build finished."
 
 pseudoxml:
 	$(SPHINXBUILD) -b pseudoxml $(ALLSPHINXOPTS) $(BUILDDIR)/pseudoxml
 	@echo
-	@echo "Build finished. The pseudo-XML files are in $(BUILDDIR)/pseudoxml."
+	@echo "Build finished."

--- a/doc/README.md
+++ b/doc/README.md
@@ -6,7 +6,17 @@ This sub-tree contains the overview documentation and generation system for
 the GA4GH API.  The generation is based on [Sphinx](http://sphinx-doc.org/),
 with documentation being extracted from the schemas.
 
+**[The documentation is available for your perusal on ReadTheDocs](http://ga4gh-schemas.readthedocs.org)**
 
-A daily build of the documentation is temporally available here:
+A daily build of the documentation is temporarily available here:
  
 http://hgwdev.cse.ucsc.edu/~markd/ga4gh/documentation-pr/
+
+# Building the Documentation
+
+The documentation is built using Sphinx, which is run through Maven in top-level
+project directory. See [INSTALL.md](../INSTALL.md) for instructions on building
+the documentation.
+
+In particular, the Makefile seen here **cannot** be used to manually build the
+documentation.

--- a/tools/sphinx/generate_sphinx_docs.sh
+++ b/tools/sphinx/generate_sphinx_docs.sh
@@ -3,14 +3,15 @@
 set -beEu -o pipefail
 
 # Script to generate the sphinx documentation
-# Run from inside schemas/sphinx
+#
+# Instead of running this script, you probably want to run "mvn package" from
+# the root of the repository.
 
 # Expects sphinx and pypandoc to be installed
 
-# Meant to be run from the Maven build, so set our cwd relative to the top-level dir
-cd doc
+# This script expects to run from the repository root.
 
-GENERATED_DOCS_LOC=../target/generated-docs
+GENERATED_DOCS_LOC=target/generated-docs
 RST_LOC=$GENERATED_DOCS_LOC/rst
 RST_SCHEMAS_LOC=$RST_LOC/schemas
 # HTML_LOC is where the final output goes.  It's relative to $GENERATED_DOCS_LOC.
@@ -23,7 +24,7 @@ mkdir -p $RST_SCHEMAS_LOC
 # Generate AVPR files
 
 # Are the Avro tools installed?
-AVRO_TOOLS_LOC=../target/avro-tools
+AVRO_TOOLS_LOC=target/avro-tools
 if [ ! -f $AVRO_TOOLS_LOC/avro-tools.jar ]
 then
     # Download them if not
@@ -34,11 +35,11 @@ then
 fi
 
 # Make a directory for all the .avpr files
-mkdir -p ../target/schemas
+mkdir -p target/schemas
 
 echo Processing AVDL files...
 
-for AVDL_FILE in ../src/main/resources/avro/*.avdl
+for AVDL_FILE in src/main/resources/avro/*.avdl
 do
     # Make each AVDL file into a JSON AVPR file:
 
@@ -46,7 +47,7 @@ do
     SCHEMA_NAME=$(basename "$AVDL_FILE" .avdl)
 
     # Decide what AVPR file it will become.
-    AVPR_FILE="../target/schemas/${SCHEMA_NAME}.avpr"
+    AVPR_FILE="target/schemas/${SCHEMA_NAME}.avpr"
 
     # Compile the AVDL to the AVPR
     java -jar $AVRO_TOOLS_LOC/avro-tools.jar idl "${AVDL_FILE}" "${AVPR_FILE}"
@@ -57,13 +58,13 @@ echo
 echo Writing HTML pages. This will take a few moments...
 
 # copy the written documentation to the merged directory
-cp -pr source/* $RST_LOC
+cp -pr doc/source/* $RST_LOC
 
 # convert AVPR to reST, then use sphinx to generate all the docs
-python ../tools/sphinx/avpr2rest.py ../target/schemas/*.avpr $RST_SCHEMAS_LOC
-cp Makefile $GENERATED_DOCS_LOC
+python tools/sphinx/avpr2rest.py target/schemas/*.avpr $RST_SCHEMAS_LOC
+cp doc/Makefile $GENERATED_DOCS_LOC
 (cd $GENERATED_DOCS_LOC; make html BUILDDIR=$HTML_LOC)
 
 echo
-echo Complete!
+echo Complete! Your documentation is available in $GENERATED_DOCS_LOC/$HTML_LOC/html
 echo


### PR DESCRIPTION
We change the documentation readme and add messages to a few places to
point would-be documentation generators towards running `mvn package` in
the repository root. We also let them know where the generated
documentation will land. Finally, we add links in the READMEs to
`INSTALL.md` and to the ReadTheDocs documentation, so they don't need to
build it themselves at all.