### PR TITLE
Setup includes for glossary

### DIFF
--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -79,7 +79,7 @@ language = None
 
 # List of patterns, relative to source directory, that match files and
 # directories to ignore when looking for source files.
-exclude_patterns = ['_build']
+exclude_patterns = ['_build', 'includes/*']
 
 # The reST default role (used for this markup: `text`) to use for all
 # documents.

--- a/doc/source/glossary.rst
+++ b/doc/source/glossary.rst
@@ -1,0 +1,14 @@
+.. _glossary:
+
+
+************
+Glossary
+************
+
+A compendium of bioinformatics terminology commonly used across the API.
+
+--------
+Reads
+--------
+
+.. include:: /includes/glossary/short_reads.rst

--- a/doc/source/glossary.rst
+++ b/doc/source/glossary.rst
@@ -7,8 +7,5 @@ Glossary
 
 A compendium of bioinformatics terminology commonly used across the API.
 
---------
-Reads
---------
 
 .. include:: /includes/glossary/short_reads.rst

--- a/doc/source/includes/glossary/short_reads.rst
+++ b/doc/source/includes/glossary/short_reads.rst
@@ -1,0 +1,31 @@
+------------
+Short Reads
+------------
+
+High throughput genome and transcriptome sequencing produces millions of short (50-200 nucleotide) sequences.
+These sequences are usually referred to as reads. Reads can be produced from:
+
+#. Complete genomes. These reads can be used to piece together the full genome of an individual.
+#. Exomes. These reads are derived from just the gene regions in the genome (in humans this is a reduction of >97%)
+#. Transcriptomes. Here, the RNA that gets transcribed from the genomic DNA is sequenced, representing only the genes that are active in the tissue that was sampled. Transcriptomes differ from tissue to tissue and can be used to determine differences between tumors and their surrounding tissues.
+
+Reads are usually mapped to a reference genome, for example `GRCh37`_ in humans.
+
+These alignments can be displayed like so::
+
+    ID      CHROM  POS    CIGAR   SEQUENCE  
+    read1   chr1   234    10M     GACAGTCCCA  
+    read2   chr14  1456   10M     AAAGATTGAC  
+    read3   chrX   2837   7M2I1M  TGGGACTCTA  
+
+
+In this format, the CIGAR string shows how well the read matches the genome: read1 is identical to the genome sequence over all its
+10 bases: 10M. The first seven bases of read3 match the genome (7M), but then it has a 2 base insertion (2I), followed by another 1 base match (1M).
+
+The `SAM/BAM Format`_ is a way of representing read data. It includes the fields shown above as well as information on read orientation, sequence quality, and optional fields. The format also allows for reads that do not align to the genome, by leaving the reference sequence ID, position, and cigar fields empty.
+
+Sam is a human readable format, bam is a condensed binary format. The formats can be readily converted to each other.
+
+.. _SAM/BAM Format: https://samtools.github.io/hts-specs/SAMv1.pdf
+
+.. _GRCh37: http://www.ncbi.nlm.nih.gov/assembly/GCF_000001405.13

--- a/doc/source/index.rst
+++ b/doc/source/index.rst
@@ -34,3 +34,5 @@ Contents
     schemas/variantmethods
     schemas/variants
 
+    glossary
+

--- a/doc/source/reads_intro.rst
+++ b/doc/source/reads_intro.rst
@@ -6,38 +6,7 @@ Reads API
 
 For the Reads schema definitions, see `Reads schema <schemas/reads.html>`_
 
-
-------------
-Short Reads
-------------
-
-High throughput genome and transcriptome sequencing produces millions of short (50-200 nucleotide) sequences.
-These sequences are usually referred to as reads. Reads can be produced from:
-
-#. Complete genomes. These reads can be used to piece together the full genome of an individual.
-#. Exomes. These reads are derived from just the gene regions in the genome (in humans this is a reduction of >97%)
-#. Transcriptomes. Here, the RNA that gets transcribed from the genomic DNA is sequenced, representing only the genes that are active in the tissue that was sampled. Transcriptomes differ from tissue to tissue and can be used to determine differences between tumors and their surrounding tissues.
-
-Reads are usually mapped to a reference genome, for example `GRCh37`_ in humans.
-
-These alignments can be displayed like so::
-
-    ID      CHROM  POS    CIGAR   SEQUENCE  
-    read1   chr1   234    10M     GACAGTCCCA  
-    read2   chr14  1456   10M     AAAGATTGAC  
-    read3   chrX   2837   7M2I1M  TGGGACTCTA  
-
-
-In this format, the CIGAR string shows how well the read matches the genome: read1 is identical to the genome sequence over all its
-10 bases: 10M. The first seven bases of read3 match the genome (7M), but then it has a 2 base insertion (2I), followed by another 1 base match (1M).
-
-The `SAM/BAM Format`_ is a way of representing read data. It includes the fields shown above as well as information on read orientation, sequence quality, and optional fields. The format also allows for reads that do not align to the genome, by leaving the reference sequence ID, position, and cigar fields empty.
-
-Sam is a human readable format, bam is a condensed binary format. The formats can be readily converted to each other.
-
-.. _SAM/BAM Format: https://samtools.github.io/hts-specs/SAMv1.pdf
-
-.. _GRCh37: http://www.ncbi.nlm.nih.gov/assembly/GCF_000001405.13
+.. include:: /includes/glossary/short_reads.rst
 
 ------------------
 The Reads Schema


### PR DESCRIPTION
Moved short_reads section into glossary includes, also included in reads API description.