### PR TITLE
Revise Avro and JSON documentation

### DIFF
--- a/doc/source/appendix/json_intro.rst
+++ b/doc/source/appendix/json_intro.rst
@@ -1,15 +1,89 @@
 .. _json:
 
 **********************
-The JSON Format	(stub)
+The JSON Format
 **********************
 
-format described `here <http://json.org/example>`_
+JSON, or JavaScript Object Notation, is officially defined `here <http://json.org/example>`_. It is the standard data interchange format for web APIs.
 
-..todo::
-   show example of GH4GH JSON output
+The GA4GH Web API uses a JSON wire protocol, exchanging JSON representations of the objects defined in its AVDL schemas. More information on the AVDL schemas is available in :ref:`avro`; basically, the AVDL type definitions say what attributes any given JSON object ought to have, and what ought to be stored in each of them.
 
-This is from the `ga4gh server example`_
+-----------------------
+GA4GH JSON Serialization
+-----------------------
+
+The GA4GH web APIs use Avro IDL to define their schemas, and use the associated Avro JSON serialization libraries. Since the schemas use a restricted subset of AVDL types (see `A note on unions`_ below), the serialized JSON format is fairly standard. This means that standard non-Avro JSON serialization and deserialization libraries (like, for example, the Python ``json`` module) can be used to serialize and deserialize GA4GH JSON messages in an idiomatic way.
+
+---------------------
+Serialization example
+---------------------
+
+For example, here is the schema definition for Variants (with comments removed)::
+
+  record Variant {
+    string id;
+    string variantSetId;
+    array<string> names = [];
+    union { null, long } created = null;
+    union { null, long } updated = null;
+    string referenceName;
+    long start;
+    long end;
+    string referenceBases;
+    array<string> alternateBases = [];
+    map<array<string>> info = {};
+    array<Call> calls = [];
+  }
+
+Here is a serialized variant in JSON. It's a bit of an edge case in some respects::
+
+  {
+      "id": "gv79384-3200-11",
+      "variantSetId": "vs-44-1",
+      "names": [
+          "rs110",
+          "Victoria"
+      ],
+      "created": 1446842841,
+      "updated": null,
+      "start": 1000,
+      "end": 1001,
+      "referenceBases": "A",
+      "alternateBases": [
+          "C",
+          "CTATCTT"
+      ],
+      "info": {
+          "variantfacts": ["is_interesting", "is_long"],
+          "numberOfPapers": ["11"]
+      },
+  }
+
+Things to notice:
+ * A serialized record contains no explicit information about its type.
+ * Arrays are serialized as JSON arrays.
+ * Maps are serialized as JSON objects.
+ * Records are also serialized as JSON objects.
+ * Enums (not shown here) are serialized as JSON strings.
+ * Nulls are serialized as JSON nulls.
+ * Fields with default values may be omitted (see the lack of an ``updated`` or ``calls``) as a way of serializing their default values.
+ * Unions of ``null`` and a non-``null`` type are serialized as either ``null`` or the serialized non-null value. No other kinds of unions are present or permitted.
+
+-----------------------
+A note on unions
+-----------------------
+
+As noted above, a field with union type serialized in GA4GH JSON looks no different from a field of any other type: you just put the field name and its recursively serialized value. In order for the Avro JSON libraries to support this, it is necessary that AVDL ``union`` types union together only ``null`` and a single non-``null`` type. If there were two or more non-``null`` types, the Avro libraries would need to include additional type information to say which to use when deserializing. Since we prohibit those unions, however, API clients and alternative server implementations never need to worry about this additional type information or its syntax. They can just handle "normal" JSON.
+
+.. todo::
+   * add example of Python decoder output
+   * create a python class, if necessary
+   
+-----------------------
+Wire protocol example
+-----------------------
+
+This is from the `ga4gh server example`_.
 
 .. _ga4gh server example: http://ga4gh-reference-implementation.readthedocs.org/en/stable/demo.html#demo
 

--- a/doc/source/intro.rst
+++ b/doc/source/intro.rst
@@ -37,28 +37,15 @@ whole genome annotations, the API allows retrieval of information on, for instan
 
 For a full list of the GA4GH API goals, see :ref:`apigoals`
 
-The API consists of a series of :ref:`apidefinition`, or schemas, that define datasets, metadata, read group sets, reads, variants, etc. 
+---------------------------
+Schemas and formats
+---------------------------
 
-The schemas are written in Avro Interactive Data Language (extension .avdl). 
+The API consists of a series of :ref:`apidefinition`, or schemas, that define the types of things that API clients and servers exchange: requests for data, server responses, error messages, and objects actually representing pieces of genomics data.
 
-:ref:`avro` is a data serialization system, it defines how data gets transported across the internet.
-Here, data means both the request ('send me RNASeq for gene X in sample Y') and the response (the BAM file). Apache Avro only sends data in
-:ref:`json` or Binary Avro format, so requests and responses must be converted into one of those formats.
+The schemas are written in Avro Interface Description Language (extension .avdl). For more details on Avro and how it is used in the GA4GH APIs, see :ref:`avro`.
 
-For more details on AVRO, see :ref:`avro`
-
-For more details on JSON, see :ref:`json`
-
-
------------------------
-How to use Avro schemas
------------------------
-The GA4GH web API schemas show developers how to make servers and clients interact. 
-They define how the data is organized, and thereby give information on what can be requested.
-The schemas can be used to create code in any programming language.
-
-
-Here's the schema definition for Variants (with comments removed)::
+Here is an example schema definition for a Variant (with comments removed)::
 
   record Variant {
     string id;
@@ -75,14 +62,11 @@ Here's the schema definition for Variants (with comments removed)::
     array<Call> calls = [];
   }
 
-This means that when you request a single variant by, for example, its ID, you get back a JSON file
-with the information listed above. The JSON can be read using the JSON decoder from the
-Python standard library, which creates (an object?) in which the JSON array becomes Python's list, 
-and any NULL values become None.
+On the wire, the GA4GH web API takes the form of a client and a server exchanging JSON-serialized objects over HTTP or HTTPS. For more details on JSON, including how the GA4GH web API serializes and deserializes Avro-specified objects in JSON, see :ref:`json`.
 
-.. todo::
-   * add example of decoder output
-   * create a python class, if necessary
+------------------------------
+Sample code
+------------------------------
 
-Click for more :ref:`samplecode`.
+API sample code and examples are available at :ref:`samplecode`.
 


### PR DESCRIPTION
In GA4GH world, we use only the AVDL part of Avro, and we serialize to
JSON in our own special simple way. This previously was not documented.
Now it is.

I've also put some information (to be expanded) on how we define an API
by defining a bunch of objects.