### PR TITLE
Fix the section definition for apigoals. It is referenced elsewhere

### DIFF
--- a/doc/source/api/apigoals_intro.rst
+++ b/doc/source/api/apigoals_intro.rst
@@ -1,4 +1,4 @@
-...... _apigoals:
+.. _apigoals:
 
 ***************************
 GA4GH API Goals


### PR DESCRIPTION
and generates an error during the build.