### PR TITLE
Improve specificity of the Reads API documentation.

### DIFF
--- a/src/main/resources/avro/readmethods.avdl
+++ b/src/main/resources/avro/readmethods.avdl
@@ -11,11 +11,11 @@ This request maps to the body of `POST /reads/search` as JSON.
 
 If a reference is specified, all queried `ReadGroup`s must be aligned
 to `ReferenceSet`s containing that same `Reference`. If no reference is
-specified, all `ReadGroup`s must be aligned to the same `ReferenceSet`.
+specified, all queried `ReadGroup`s must be aligned to the same `ReferenceSet`.
 */
 record SearchReadsRequest {
   /**
-  The ReadGroups to search. At least one readGroupId must be specified.
+  The ReadGroups to search. At least one id must be specified.
   */
   array<string> readGroupIds;
 
@@ -72,7 +72,20 @@ record SearchReadsResponse {
 }
 
 /**
-Gets a list of `ReadAlignment` matching the search criteria.
+Gets a list of `ReadAlignment`s for one or more `ReadGroup`s.
+
+`searchReads` operates over a genomic coordinate space of reference sequence
+and position defined by the `Reference`s to which the requested `ReadGroup`s are
+aligned.
+
+If a target positional range is specified, search returns all reads whose
+alignment to the reference genome *overlap* the range. A query which specifies
+only read group IDs yields all reads in those read groups, including unmapped
+reads.
+
+All reads returned (including reads on subsequent pages) are ordered by genomic
+coordinate (by reference sequence, then position). Reads with equivalent genomic
+coordinates are returned in an unspecified but deterministic order.
 
 `POST /reads/search` must accept a JSON version of `SearchReadsRequest` as
 the post body and will return a JSON version of `SearchReadsResponse`.
@@ -84,14 +97,12 @@ SearchReadsResponse searchReads(
 /******************  /readgroupsets/search  *********************/
 /** This request maps to the body of `POST /readgroupsets/search` as JSON.
 
-If the `name` doesn't match any read group sets, the `readGroupSets` field in the
-resulting `SearchReadGroupSetsResponse` will be empty.
-
-_Error Conditions_
-
-- If `datasetId` refers to a nonexistent dataset, this method will throw `GAException` and set the HTTP
-status code to `404` (`NOT_FOUND`).
- */
+TODO: Factor this out to a common API patterns section.
+- If searching by a resource ID, and that resource is not found, the method
+will return a `404` HTTP status code (`NOT_FOUND`).
+- If searching by other attributes, e.g. `name`, and no matches are found, the
+method will return a `200` HTTP status code (`OK`) with an empty result list.
+*/
 record SearchReadGroupSetsRequest {
   /**
   The dataset to search.

--- a/src/main/resources/avro/reads.avdl
+++ b/src/main/resources/avro/reads.avdl
@@ -1,168 +1,101 @@
 @namespace("org.ga4gh.models")
 
 /**
-This file defines the objects used to represent a hierarchy of reads and alignments:
-
-ReadGroupSet >--< ReadGroup --< fragment --< read --< alignment --< linear alignment
-
-`FIXME:  This order does not appear to exist like this and is not linear`
-
-If `>--<` means contains and `-->` and `<--` mean pointer, then currently:
-
-    ReadGroupSet >--< ReadGroup  <--- ReadAlignment >--< Linear alignment <--> Common.CigarUnit  
-                                                    ---> fragment  
-                                  ---> Metadata.Dataset  
-                                  ---> Metadata.Sample  
-                                  <--> Metadata.Experiment  
-                                  ---> Reference.ReferenceSet  
-                                  <--> ReadStats  
-                 >--< ReadStats  
-                 ---> Metadata.Dataset
-
-`NOTE: ReadAlignment is the only record that no other records point to (or contain) so ReadAlignment should really be the root` :
-
-    ReadAlignment >--< linear alignment <--> Common.CigarUnit
-                  ---> fragment
-                  ---> ReadGroup              >--< ReadGroupSet <--> ReadStats
-                                                                ---> Metadata.Dataset
-                                              ---> Metadata.Dataset
-                                              ---> Metadata.Sample
-                                              <--> Metadata.Experiment
-                                              ---> Reference.ReferenceSet
-                                              <--> ReadStats
-
-`NOTE: The below probably needs to be rewritten entirely, but I have added some notes anyway.`
-
-* A ReadGroupSet is a logical collection of ReadGroups. `FIXME: Logical how? Is it all samples from an experiment?`
-* A ReadGroup is all the data that's processed the same way by the sequencer.
-`FIXME: What is a sequencer? A machine? What's an example of 'processed the same way'?`
- There are typically 1-10 ReadGroups in a ReadGroupSet.
-* A *fragment* is a single stretch of a DNA molecule. There are typically
- millions of fragments in a ReadGroup. A fragment has a name (QNAME in BAM
- spec), a length (TLEN in BAM spec), and an array of reads.
-`FIXME: Fragment seems very similar to Reference.Reference. Why not use that?`
-* A *read* is a contiguous sequence of bases. There are typically only one or
- two reads in a fragment. If there are two reads, they're known as a mate pair.
- A read has an array of base values, an array of base qualities, and alignment
- information.
-* An *alignment* is a mapping of a read to a reference.
- There's one primary alignment, `typically randomly chosen by the alignment software`,
- and there can be one or more secondary alignments.
- Secondary alignments represent alternate possible mappings.
-* A *linear alignment* maps a string of bases to a reference using a single
- CIGAR string. There's one representative alignment, and can be one or more
- supplementary alignments. Supplementary alignments represent linear alignments
- that are subsets of a chimeric alignment.
-* A ReadAlignment object is a flattened representation of the bottom layers
- of this hierarchy. There's exactly one such object per *linear alignment*. The
- object contains alignment info, plus fragment and read info for easy access.
- CIGAR string. There's one representative alignment, and there can be one or more
- supplementary alignments. Supplementary alignments represent linear or graph
- alignments that are subsets of a chimeric alignment.
-`FIXME: how is a supplementary alignment different from a secondary alignment?`
-* A ReadAlignment object is a flattened representation of the bottom layers
- of this hierarchy. There's exactly one such object per *linear alignment* or
- *graph alignment*. The object contains alignment info, plus fragment and read
- info for easy access.
-`FIXME: This is completely unclear as written. Maybe split graph and linear alignments and discuss separately.`
-
+This file defines the objects used to represent a reads and alignments, most importantly
+ReadGroupSet, ReadGroup, and ReadAlignment.
+See {TODO: LINK TO READS OVERVIEW} for more information.
 */
-
 protocol Reads {
 
 import idl "common.avdl";
 import idl "metadata.avdl";
 
 /**
-A Program is `public?` software that is used to create read alignments `NOTE: if it's more generic than this, 
-it does not belong in the Reads schema`. Each Program record must contain a unique ID, the program name
-(e.g. bowtie) and the program's version (e.g. v.0.1.2). Optionally another program ID can be entered which
-points to another program that was run before the current program.
-
-`NOTE: Removed most optional null values from original, because Program Name, Program ID etc should not
-be allowed to be null`
-
+Program can be used to track the provenance of how read data was generated.
 */
 record Program {
-  /** The UUID of the program. */
-  string id;
+  /** The command line used to run this program. */
+  union { null, string } commandLine = null;
+
+  /** The user specified ID of the program. */
+  union { null, string } id = null;
 
   /** The name of the program. */
-  string name;
-
-  /** The command line used to run this program. */
-  string commandLine;
-
-  /** The version of the program run. */
-  string version;
+  union { null, string } name = null;
 
   /** The ID of the program run before this one. */
   union { null, string } prevProgramId = null;
 
+  /** The version of the program run. */
+  union { null, string } version = null;
 }
 
-/**
-ReadStats holds information on ReadGroups or ReadGroupSets.`NOTE: Must expand description`
-
-`FIXME: This record should hold the output of Samtools flagstat, or equivalent.` 
-See [this ticket] (https://github.com/Jeltje/ga4gh-schemas/issues/12)
-
-`NOTE: Removed optional null values`
-*/
+/** ReadStats can be used to provide summary statistics about read data. */
 record ReadStats {
   /** The number of aligned reads. */
-  long alignedReadCount;
+  union { null, long } alignedReadCount = null;
 
   /** The number of unaligned reads. */
-  long unalignedReadCount;
+  union { null, long } unalignedReadCount = null;
 
   /**
   The total number of bases.
   This is equivalent to the sum of `alignedSequence.length` for all reads.
   */
-  long  baseCount;
+  union { null, long } baseCount = null;
 }
 
 /**
-A ReadGroup is a collection of `ReadAlignment`s. This is equivalent to a SAM file.
-
-`FIXME: Explain why nearly all values are allowed to be null. It seems most of them should not be`
-
-`REMOVED: created and updated fields. Timestamps should not be part of these records, because they will
-not be updated (they can be deleted or stored under a new ID if information changes)`
+A ReadGroup is a set of reads derived from one physical sequencing process.
 */
 record ReadGroup {
 
-  /** The UUID of the read group. */
+  /** The read group ID. */
   string id;
 
-  /** The ID of the `Dataset` that describes this read group. `EXPLAIN: Why can this be null? Can a ReadGroup NOT be part of a Dataset?`*/
+  /** The ID of the dataset this read group belongs to. */
   union { null, string } datasetId = null;
 
-  /** The read group name. `FIXME: This should probably not be null` */
+  /** The read group name. */
   union { null, string } name = null;
 
-  /** The read group description. `EXPLAIN: What kind of description?` */
+  /** The read group description. */
   union { null, string } description = null;
 
-  /** The ID of the `Sample` record that describes the sample that was sequenced. `FIXME: Sample is not defined anywhere (used to be in metadata)`*/
+  /**
+  The sample this read group's data was generated from.
+  Note: the current API does not have a rigorous definition of sample. Therefore, this
+  field actually contains an arbitrary string, typically corresponding to the SM tag in a
+  BAM file.
+  */
   union { null, string } sampleId;
 
-  /** The `Experiment` used to generate this read group. `FIXME: This should not be null`*/
+  /** The experiment used to generate this read group. */
   union { null, Experiment } experiment;
 
-  /** The predicted insert size of this read group. `EXPLAIN: This should probably only be null if the reads were not paired end`*/
+  /** The predicted insert size of this read group. */
   union { null, int } predictedInsertSize = null;
 
-  /** The `ReadStats` statistical data on reads in this read group. `FIXME: This should probably not be null`*/
+  /**
+  The time at which this read group was created in milliseconds from the epoch.
+  */
+  union { null, long } created = null;
+
+  /**
+  The time at which this read group was last updated in milliseconds
+  from the epoch.
+  */
+  union { null, long } updated = null;
+
+  /** Statistical data on reads in this read group. */
   union { null, ReadStats } stats = null;
 
-  /** The `Program`s used to generate `Align? Filter?` this read group. `FIXME: This should probably not be empty`*/
+  /** The programs used to generate this read group. */
   array<Program> programs = [];
 
   /**
-  The ID of the `ReferenceSet` record that describes the sequence the reads in this read group are aligned to.
-  Required if there are any read alignments. `EXPLAIN: Are there expected to be ReadGroups that only have unaligned reads?`
+  The ID of the reference set to which the reads in this read group are aligned.
+  Required if there are any read alignments.
   */
   union {null, string } referenceSetId = null;
 
@@ -173,47 +106,49 @@ record ReadGroup {
 }
 
 /**
-A ReadGroupSet is a collection of `ReadGroup`s. If read groups are equivalent to SAM files, then a read group set can be a collection
-of SAM files that were generated from a single sequencing run.   
-All read groups in the set are required to map to the same referenceSet.
-
-`FIXME: Add proper description of ReadGroupSet`
-
-`FIXME: Explain why nearly all values are allowed to be null. It seems most of them should not be`
+A ReadGroupSet is a logical collection of ReadGroups. Typically one ReadGroupSet
+represents all the reads from one experimental
+sample.
 */
 record ReadGroupSet {
-  /** The UUID of the ReadGroupSet.*/
+  /** The read group set ID. */
   string id;
 
-  /** The ID of the `Dataset` this read group set belongs to. `EXPLAIN: Why can this be null? Can a ReadGroup NOT be part of a Dataset?`*/
+  /** The ID of the dataset this read group set belongs to. */
   union { null, string } datasetId = null;
 
-  /** The read group set name. `FIXME: This should probably not be null`*/
+  /** The read group set name. */
   union { null, string } name = null;
 
-  /** The `ReadStats` statistical data on reads in this read group set . `FIXME: This should probably not be null`*/
+  /** Statistical data on reads in this read group set. */
   union { null, ReadStats } stats = null;
 
-  /** The `ReadGroup`s that make up this read group set. */
+  /** The read groups in this set. */
   array<ReadGroup> readGroups = [];
 
+  // NB: we require that all readgroups in the set are mapped to the same
+  // referenceSet.
 }
 
 /**
-A LinearAlignment is a mapping of a read to a reference. It can be represented by one CIGAR string.
+A linear alignment describes the alignment of a read to a Reference, using a
+position and CIGAR array.
 */
 record LinearAlignment {
-  /** The position of this alignment `in the reference genome/sequence`. */
+  /** The position of this alignment. */
   Position position;
 
   /**
-  The mapping quality of this alignment. Represents how likely
-  the read maps to this position as opposed to other locations. `EXPLAIN: Why is this allowed to be null?`
+  The mapping quality of this alignment, meaning the likelihood that the read
+  maps to this position.
+
+  Specifically, this is -10 log10 Pr(mapping position is wrong), rounded to the
+  nearest integer.
   */
   union { null, int } mappingQuality = null;
 
   /**
-  The list of `CigarUnit`s that represent the local alignment of this sequence (alignment matches, indels, etc)
+  Represents the local alignment of this sequence (alignment matches, indels, etc)
   versus the reference.
   */
   array<CigarUnit> cigar = [];
@@ -222,8 +157,7 @@ record LinearAlignment {
 /**
 A fragment represents a contiguous stretch of a DNA or RNA molecule. Reads can
 be associated with a fragment to specify they derive from the same molecule.
-`EXPLAIN: How is Fragment different from Reference?` Also see [this ticket] (https://github.com/Jeltje/ga4gh-schemas/issues/11)
-
+TODO: this Fragment object is essentially unused, and may be removed in a future PR.
 */
 record Fragment {
 
@@ -241,9 +175,11 @@ record ReadAlignment {
 
   /**
   The read alignment ID. This ID is unique within the read group this
-  alignment belongs to. This field may not be provided by all backends. `Explain: Why not?`
-  Its intended use is to make caching and UI display easier for
-  genome browsers and other light weight clients.
+  alignment belongs to.
+
+  For performance reasons, this field may be omitted by a backend.
+  If provided, its intended use is to make caching and UI display easier for
+  genome browsers and other lightweight clients.
   */
   union { null, string } id;
 
@@ -254,44 +190,41 @@ record ReadAlignment {
   string readGroupId;
 
   // fragment attributes
-  
-  /** The fragment ID that this ReadAlignment belongs to. 
- 
-  `FIXME: To be consistent with other records, this should be replaced with ReferenceId.` See [this ticket] (https://github.com/Jeltje/ga4gh-schemas/issues/11)
+
+  /**
+  The fragment ID that this ReadAlignment belongs to.
+  TODO: this is the only reference to the Fragment object, which may be removed in a future PR.
   */
   string fragmentId;
 
-  /** The fragment name. Equivalent to QNAME (query template name) in SAM.
-	
-  `FIXME: This should then be ReferenceSequenceId`
-  */
+  /** The fragment name. Equivalent to QNAME (query template name) in SAM. */
   string fragmentName;
 
   /**
   The orientation and the distance between reads from the fragment are
-  consistent with the sequencing protocol (equivalent to SAM flag 0x2). Can only be null if it hasn't been computed.
+  consistent with the sequencing protocol (equivalent to SAM flag 0x2)
   */
   union { null, boolean } properPlacement = null;
 
-  /** The fragment is a PCR or optical duplicate `(both are technical artefacts)` (SAM flag 0x400) */
+  /** The fragment is a PCR or optical duplicate (SAM flag 0x400). */
   union { null, boolean } duplicateFragment = null;
 
-  /** The number of reads in the fragment (extension to SAM flag 0x1) `EXPLAIN: Why can this be null? Should it be zero if none are found? CAN none be found?`*/
+  /** The number of reads in the fragment (extension to SAM flag 0x1) */
   union { null, int } numberReads = null;
 
-  /** The observed length of the fragment, equivalent to TLEN in SAM. `EXPLAIN: Why can this be null? Should it be zero if none are found? CAN none be found?`*/
+  /** The observed length of the fragment, equivalent to TLEN in SAM. */
   union { null, int } fragmentLength = null;
 
   // read attributes
 
   /**
-  The read number in sequencing. 0-based and less than numberReads. This field
-  replaces SAM flag 0x40 and 0x80. `UNCLEAR, please define better. SAM flags 0x40 and 0x80 are first and second read in pair, respectively. How does this
-  map to readNumber?` `Explain: Why can this be null?`
+  The read ordinal in the fragment, 0-based and less than numberReads. This
+  field replaces SAM flag 0x40 and 0x80 and is intended to more cleanly
+  represent multiple reads per fragment.
   */
   union { null, int } readNumber = null;
 
-  /** SAM flag 0x200, read fails platform or vendor quality checks */
+  /** The read fails platform or vendor quality checks (SAM flag 0x200). */
   union { null, boolean } failedVendorQualityChecks = null;
 
   /**
@@ -327,25 +260,25 @@ record ReadAlignment {
   union { null, boolean } supplementaryAlignment = null;
 
   /**
-  The bases of the read sequence contained in this alignment record.
+  The bases of the read sequence contained in this alignment record (equivalent
+  to SEQ in SAM).
+
   `alignedSequence` and `alignedQuality` may be shorter than the full read sequence
   and quality. This will occur if the alignment is part of a chimeric alignment,
   or if the read was trimmed. When this occurs, the CIGAR for this read will
-  begin/end with a hard clip operator that will indicate the length of the excised sequence.
-
-  `Explain: Is this equivalent to the SEQ SAM field?`
+  begin/end with a hard clip operator that will indicate the length of the
+  excised sequence.
   */
   union { null, string } alignedSequence = null;
 
   /**
-  The quality of the read sequence contained in this alignment record.
+  The quality of the read sequence contained in this alignment record
+  (equivalent to QUAL in SAM).
+
   `alignedSequence` and `alignedQuality` may be shorter than the full read sequence
   and quality. This will occur if the alignment is part of a chimeric alignment,
   or if the read was trimmed. When this occurs, the CIGAR for this read will
   begin/end with a hard clip operator that will indicate the length of the excised sequence.
-
-  `Explain: Is this equivalent to the QUAL SAM field? If so, why is it an array, not a string? If not, how does it compare?`
-
   */
   array<int> alignedQuality = [];
 
@@ -357,8 +290,6 @@ record ReadAlignment {
 
   /**
   A map of additional read alignment information.
-
-  `Explain: Is this where the SAM TAGs go? There seem to be more precise ways to define SAM TAGs, should there be a separate record for those?`
   */
   map<array<string>> info = {};
 }


### PR DESCRIPTION
Improved specificity in places and removed FIXMEs and open questions. Also made some wording tweaks and style consistency changes.

The overview documentation for the Reads protocol was removed and will be reincarnated in reads.rst.

Reverted any changes to the schema (from master) we considered to be out of scope:
- Reverted removal of `created` and `updated` fields
- Reverted changes to nullability.