### PR TITLE
Fix bugs in Variants API RST markup

### DIFF
--- a/doc/source/api/variants.rst
+++ b/doc/source/api/variants.rst
@@ -4,7 +4,7 @@
 Variants API
 *******************
 
-For the Variant schema definitions, see the `Variants schema <schemas/variants.html>`_
+For the Variant schema definitions, see the `Variants schema <../schemas/variants.html>`_
 
 ------------------
 Introduction: Genetic Variants and VCF
@@ -12,7 +12,7 @@ Introduction: Genetic Variants and VCF
 
 Genetic variants are differences in the genome sequence from one individual to the next. Such variation can manifest at different scales, from small changes affecting just one or a few DNA base pairs, to copy number variations of whole exons or genes, to large structural variations affecting megabases or more. The GA4GH Variants API focuses on small variants for now, because there's less consensus on how to represent the larger kinds of variation.
 
-Small genetic variants can be represented as edits to a Reference sequence: typically a tuple of (1) Reference sequence name, (2) starting position of the affected portion on the Reference sequence, (3) DNA sequence of the affected portion of the Reference, and (4) alternate DNA sequence found in some individual in place of the reference sequence. Both the reference and alternate sequences are specified in order to represent sequence insertions and deletions (indels). A few examples:
+Small genetic variants can be represented as edits to a Reference sequence: typically a tuple of (1) Reference sequence name, (2) starting position of the affected portion on the Reference sequence, (3) DNA sequence of the affected portion of the Reference, and (4) alternate DNA sequence found in some individual in place of the reference sequence. Both the reference and alternate sequences are specified in order to represent sequence insertions and deletions (indels). A few examples::
 
     CHROM  POS     REF  ALT  
     20     14370   G    A 
@@ -23,6 +23,8 @@ The first variant is a single-nucleotide substitution of G to A. The second vari
 
 Given a list of such variants, we can then represent the genotype of one or more individuals with respect to each variant. For an autosomal variant, the genotype of a diploid individual may take one of three distinct values: homozygous reference (0,0), heterozygous (0,1), or homozygous alternate (1,1). We can therefore present a matrix of genotypes, where the rows are variants as shown above, the columns are the individuals, and each entry is one of those three genotype *calls*, or marked missing.
 
+::
+
     CHROM  POS     REF  ALT   Alice   Bob
     20     14370   G    A     (0,0)   (0,1)
     20     17330   TA   T     (0,0)   (1,1)
@@ -30,13 +32,13 @@ Given a list of such variants, we can then represent the genotype of one or more
 
 (If the phase of an individual's genotypes across several variant positions is known, then the heterozygous genotypes (0,1) and (1,0) may be considered distinct.)
 
-It's possible to observe multiple different alternate sequences affecting the same regions of the reference. This can occur even within one individual, if their two chromosomes contain different non-reference sequences, and becomes somewhat common when representing a whole population. To handle these cases, we allow a variant to include multiple alternate sequences, or alleles. For example:
+It's possible to observe multiple different alternate sequences affecting the same regions of the reference. This can occur even within one individual, if their two chromosomes contain different non-reference sequences, and becomes somewhat common when representing a whole population. To handle these cases, we allow a variant to include multiple alternate sequences, or alleles. For example::
 
     CHROM  POS     REF  ALT  
     20     19254   G    A,C,T
     20     21672   AT   AC,TGA
 
-and genotypes can take values such as (0,3) or (1,2). This multi-allelic sites model was refined and popularized in the `Variant Call Format (VCF) <https://samtools.github.io/hts-specs/VCFv4.2.pdf>`_ developed in the 1000 Genomes Project, upon which the Variants API is based.
+It's also possible for genotypes to take values such as (0,3) or (1,2). This multi-allelic sites model was refined and popularized in the `Variant Call Format (VCF) <https://samtools.github.io/hts-specs/VCFv4.2.pdf>`_ developed in the 1000 Genomes Project, upon which the Variants API is based.
 
 There are some outstanding challenges with this representation of variants. For example, the same edit to the reference sequence can be represented in different ways. There are also different ways one might represent variants/alleles that affect overlapping but non-equal regions of the reference. Several different conventions are used to address these situations in practice, and the GA4GH Variants API currently does not prescribe one.
 
@@ -48,17 +50,17 @@ While the Variant schema is based on VCF, it allows for more versatile interacti
 
 The API uses four main objects to represent variants. The following diagram illustrates how these objects constitute the genotype matrix. 
 
-.. image:: _static/variant_objects.svg
+.. image:: /_static/variant_objects.svg
 
-The atomic `Call` object encodes the genotype of an individual with respect to a variant, as determined by some data analysis. The other objects can be thought of as collections of Calls that have something in common:
+The atomic :avro:record:`Call` object encodes the genotype of an individual with respect to a variant, as determined by some data analysis. The other objects can be thought of as collections of Calls that have something in common:
 
-    * a `VariantSet` supports working with a collection of Calls intended to be analyzed together
-    * a `Variant` supports working with the subset of Calls in a VariantSet for the same site of two or more alleles.
-    * a `CallSet` supports working with the subset of Calls in a VariantSet that were generated by the same analysis of the same sample.
+    * a :avro:record:`VariantSet` supports working with a collection of Calls intended to be analyzed together
+    * a :avro:record:`Variant` supports working with the subset of Calls in a VariantSet for the same site of two or more alleles.
+    * a :avro:record:`CallSet` supports working with the subset of Calls in a VariantSet that were generated by the same analysis of the same sample.
 
-The following diagram shows the hierarchical relationship of these four objects as well as other reference and metadata objects in the GA4GH API. It shows which records contain other records (such as ``VariantSetMetaData``), and which contain IDs that can be used to get information from other records (such as ``variantSetId``). The arrow points `from` the record that lists the ID `to` the record that can be identified by that ID.
+The following diagram shows the hierarchical relationship of these four objects as well as other reference and metadata objects in the GA4GH API. It shows which records contain other records (such as :avro:record:`VariantSetMetadata`), and which contain IDs that can be used to get information from other records (such as :avro:record:`Variant`'s ``variantSetId``). The arrow points *from* the record that lists the ID *to* the record that can be identified by that ID.
 
-.. image:: _static/variant_schema.png
+.. image:: /_static/variant_schema.png
 
 For the complete Variant schema definition, see the `Variants schema <schemas/variants.html>`_
 


### PR DESCRIPTION
Images should now load, and cross-references to Avro records should
now be real links.