### PR TITLE
small cleanups to metadata documentation

### DIFF
--- a/doc/source/api/metadata.rst
+++ b/doc/source/api/metadata.rst
@@ -21,31 +21,33 @@ Design
 
 **Data organization**
 
-All data objects in GA4GH are part of a *data set*. A data set is a
+All GA4GH data objects are part of a *dataset*. A dataset is a
 data-provider-specified collection of related data of multiple types.
-Logically, it's akin to a folder. It's up to the provider what goes into the
-folder.  A data objects are linked by `dataSetId` to `Dataset objects
+Logically, it's akin to a folder, where it's up to the provider what goes into the
+folder. Individual data objects are linked by `datasetId` fields to `Dataset objects
 <../schemas/metadata.html#avro.Dataset>`_.
 
-For server implementors, they're a useful level of granularity for
-implementing administrative features such as access control (e.g. Data sett X
-is public; data set Y is only available to lab Z's collaborators) and billing
-(e.g. the costs of hosting Dataset Y should be charged to lab Z).
-
-For data curators, they're 'the simplest thing that could possibly work' for
-grouping data (e.g. Dataset X has all the reads, variants, and expression
-levels for a particular research project; Dataset Y has all the work product
-from a particular grant).
-
-One should not make undue semantic assumptions on data in a data set.  A
-subset of data in a data set is normally select for analysis using other
-metadata or attributes.
+Since the grouping of content in a dataset is determined by the data provider,
+users should not make semantic assumptions about that data.  Subsets of the data
+in a dataset can be selected for analysis using other metadata or attributes.
 
 ---------
 Use Cases
 ---------
 
-TODO: use cases need to be specified
+For server implementors, datasets are a useful level of granularity for
+implementing administrative features such as access control (e.g. Data set X
+is public; data set Y is only available to lab Z's collaborators) and billing
+(e.g. the costs of hosting Dataset Y should be charged to lab Z).
+
+For data curators, datasets are 'the simplest thing that could possibly work' for
+grouping data (e.g. Dataset X has all the reads, variants, and expression
+levels for a particular research project; Dataset Y has all the work product
+from a particular grant).
+
+For data accessors, datasets are a simple way to scope exploration and analysis
+(e.g. are there any supporting examples in 1000genomes?
+what's the distribution of that result in the data from our project?)   
 
 -------------
 Issues (TODO)
@@ -53,9 +55,9 @@ Issues (TODO)
 - Metadata API is immature and under development.
 - `sampleId` is referenced in metadata, reads, and variants records of the
   schema, however there is no `Sample` object defined in metadata.
-- There is some disagreement of the role of the `Dataset` by members of the DWG.
+- There has been DWG discussion about proposing a new role for the `Dataset` object.
 - Life cycle and version management of metadata objects is not clearly defined.
-  This includes use of times
+  This includes the use of timestamps.
 - `Experiment` object is currently copied into the `ReadGroup` object.  Given
   metadata becomes a chain of objects associate with the data, coping records
   seems less that ideal.

--- a/src/main/resources/avro/metadata.avdl
+++ b/src/main/resources/avro/metadata.avdl
@@ -9,7 +9,7 @@ protocol Metadata {
 import idl "common.avdl";
 
 /**
-An experimental preparation of a `Sample`.
+An experimental preparation of a sample.
 */
 record Experiment {
   /** The experiment UUID. This is globally unique. */
@@ -35,7 +35,7 @@ record Experiment {
 
   /**
   The time at which this experiment was performed.
-  Granularity here is variabel (e.g. date only).
+  Granularity here is variable (e.g. date only).
   Format: ISO 8601, YYYY-MM-DDTHH:MM:SS (e.g. 2015-02-10T00:03:42)
   */
   union { null, string } runTime = null;
@@ -92,8 +92,8 @@ record Experiment {
 }
 
 /**
-A Dataset is a collection of related data of multiple types.  There is very
-limited semantic constraints placed on metadata.  See
+A Dataset is a collection of related data of multiple types.  There are very
+few semantic constraints placed on metadata.  See
 [Metadata API](../api/metadata.html) for a more detailed discussion.
 */
 record Dataset {


### PR DESCRIPTION
Mostly typos; a little wordsmithing; moved use cases into the use cases section.

@diekhans -- let me know if you have any questions.