### PR TITLE
(Unreverting) Improve specificity of the Reads API documentation.

### DIFF
--- a/src/main/resources/avro/readmethods.avdl
+++ b/src/main/resources/avro/readmethods.avdl
@@ -11,11 +11,11 @@ This request maps to the body of `POST /reads/search` as JSON.
 
 If a reference is specified, all queried `ReadGroup`s must be aligned
 to `ReferenceSet`s containing that same `Reference`. If no reference is
-specified, all `ReadGroup`s must be aligned to the same `ReferenceSet`.
+specified, all queried `ReadGroup`s must be aligned to the same `ReferenceSet`.
 */
 record SearchReadsRequest {
   /**
-  The ReadGroups to search. At least one readGroupId must be specified.
+  The ReadGroups to search. At least one id must be specified.
   */
   array<string> readGroupIds;
 
@@ -72,7 +72,23 @@ record SearchReadsResponse {
 }
 
 /**
-Gets a list of `ReadAlignment` matching the search criteria.
+Gets a list of `ReadAlignment`s for one or more `ReadGroup`s.
+
+`searchReads` operates over a genomic coordinate space of reference sequence
+and position defined by the `Reference`s to which the requested `ReadGroup`s are
+aligned.
+
+If a target positional range is specified, search returns all reads whose
+alignment to the reference genome *overlap* the range. A query which specifies
+only read group IDs yields all reads in those read groups, including unmapped
+reads.
+
+All reads returned (including reads on subsequent pages) are ordered by genomic
+coordinate (by reference sequence, then position). Reads with equivalent genomic
+coordinates are returned in an unspecified order. This order must be consistent
+for a given repository, such that two queries for the same content (regardless
+of page size) yield reads in the same order across their respective streams of
+paginated responses.
 
 `POST /reads/search` must accept a JSON version of `SearchReadsRequest` as
 the post body and will return a JSON version of `SearchReadsResponse`.
@@ -82,7 +98,14 @@ SearchReadsResponse searchReads(
   SearchReadsRequest request) throws GAException;
 
 /******************  /readgroupsets/search  *********************/
-/** This request maps to the body of `POST /readgroupsets/search` as JSON. */
+/** This request maps to the body of `POST /readgroupsets/search` as JSON.
+
+TODO: Factor this out to a common API patterns section.
+- If searching by a resource ID, and that resource is not found, the method
+will return a `404` HTTP status code (`NOT_FOUND`).
+- If searching by other attributes, e.g. `name`, and no matches are found, the
+method will return a `200` HTTP status code (`OK`) with an empty result list.
+*/
 record SearchReadGroupSetsRequest {
   /**
   The dataset to search.

--- a/src/main/resources/avro/reads.avdl
+++ b/src/main/resources/avro/reads.avdl
@@ -25,12 +25,17 @@ ReadGroupSet >--< ReadGroup --< fragment --< read --< alignment --< linear align
 * A ReadAlignment object is a flattened representation of the bottom layers
  of this hierarchy. There's exactly one such object per *linear alignment*. The
  object contains alignment info, plus fragment and read info for easy access.
+
+TODO: Pull this protocol documentation out to an overview RST.
 */
 protocol Reads {
 
 import idl "common.avdl";
 import idl "metadata.avdl";
 
+/**
+Program can be used to track the provenance of how read data was generated.
+*/
 record Program {
   /** The command line used to run this program. */
   union { null, string } commandLine = null;
@@ -48,6 +53,7 @@ record Program {
   union { null, string } version = null;
 }
 
+/** ReadStats can be used to provide summary statistics about read data. */
 record ReadStats {
   /** The number of aligned reads. */
   union { null, long } alignedReadCount = null;
@@ -62,6 +68,9 @@ record ReadStats {
   union { null, long } baseCount = null;
 }
 
+/**
+A ReadGroup is a set of reads derived from one physical sequencing process.
+*/
 record ReadGroup {
 
   /** The read group ID. */
@@ -76,7 +85,12 @@ record ReadGroup {
   /** The read group description. */
   union { null, string } description = null;
 
-  /** The sample this read group's data was generated from. */
+  /**
+  The sample this read group's data was generated from.
+  Note: the current API does not have a rigorous definition of sample. Therefore, this
+  field actually contains an arbitrary string, typically corresponding to the SM tag in a
+  BAM file.
+  */
   union { null, string } sampleId;
 
   /** The experiment used to generate this read group. */
@@ -103,7 +117,7 @@ record ReadGroup {
   array<Program> programs = [];
 
   /**
-  The reference set the reads in this read group are aligned to.
+  The ID of the reference set to which the reads in this read group are aligned.
   Required if there are any read alignments.
   */
   union {null, string } referenceSetId = null;
@@ -114,6 +128,10 @@ record ReadGroup {
   map<array<string>> info = {};
 }
 
+/**
+A ReadGroupSet is a logical collection of ReadGroups. Typically one ReadGroupSet
+represents all the reads from one experimental sample.
+*/
 record ReadGroupSet {
   /** The read group set ID. */
   string id;
@@ -134,14 +152,20 @@ record ReadGroupSet {
   // referenceSet.
 }
 
-/** A linear alignment can be represented by one CIGAR string. */
+/**
+A linear alignment describes the alignment of a read to a Reference, using a
+position and CIGAR array.
+*/
 record LinearAlignment {
   /** The position of this alignment. */
   Position position;
 
   /**
-  The mapping quality of this alignment. Represents how likely
-  the read maps to this position as opposed to other locations.
+  The mapping quality of this alignment, meaning the likelihood that the read
+  maps to this position.
+
+  Specifically, this is -10 log10 Pr(mapping position is wrong), rounded to the
+  nearest integer.
   */
   union { null, int } mappingQuality = null;
 
@@ -155,6 +179,7 @@ record LinearAlignment {
 /**
 A fragment represents a contiguous stretch of a DNA or RNA molecule. Reads can
 be associated with a fragment to specify they derive from the same molecule.
+TODO: this Fragment object is essentially unused, and may be removed in a future PR.
 */
 record Fragment {
 
@@ -172,9 +197,11 @@ record ReadAlignment {
 
   /**
   The read alignment ID. This ID is unique within the read group this
-  alignment belongs to. This field may not be provided by all backends.
-  Its intended use is to make caching and UI display easier for
-  genome browsers and other light weight clients.
+  alignment belongs to.
+
+  For performance reasons, this field may be omitted by a backend.
+  If provided, its intended use is to make caching and UI display easier for
+  genome browsers and other lightweight clients.
   */
   union { null, string } id;
 
@@ -185,11 +212,14 @@ record ReadAlignment {
   string readGroupId;
 
   // fragment attributes
-  
-  /** The fragment ID that this ReadAlignment belongs to. */
+
+  /**
+  The fragment ID that this ReadAlignment belongs to.
+  TODO: this is the only reference to the Fragment object, which may be removed in a future PR.
+  */
   string fragmentId;
 
-  /** The fragment name. Equivalent to QNAME (query template name) in SAM.*/
+  /** The fragment name. Equivalent to QNAME (query template name) in SAM. */
   string fragmentName;
 
   /**
@@ -198,7 +228,7 @@ record ReadAlignment {
   */
   union { null, boolean } properPlacement = null;
 
-  /** The fragment is a PCR or optical duplicate (SAM flag 0x400) */
+  /** The fragment is a PCR or optical duplicate (SAM flag 0x400). */
   union { null, boolean } duplicateFragment = null;
 
   /** The number of reads in the fragment (extension to SAM flag 0x1) */
@@ -210,12 +240,13 @@ record ReadAlignment {
   // read attributes
 
   /**
-  The read number in sequencing. 0-based and less than numberReads. This field
-  replaces SAM flag 0x40 and 0x80.
+  The read ordinal in the fragment, 0-based and less than numberReads. This
+  field replaces SAM flag 0x40 and 0x80 and is intended to more cleanly
+  represent multiple reads per fragment.
   */
   union { null, int } readNumber = null;
 
-  /** SAM flag 0x200 */
+  /** The read fails platform or vendor quality checks (SAM flag 0x200). */
   union { null, boolean } failedVendorQualityChecks = null;
 
   /**
@@ -251,16 +282,21 @@ record ReadAlignment {
   union { null, boolean } supplementaryAlignment = null;
 
   /**
-  The bases of the read sequence contained in this alignment record.
+  The bases of the read sequence contained in this alignment record (equivalent
+  to SEQ in SAM).
+
   `alignedSequence` and `alignedQuality` may be shorter than the full read sequence
   and quality. This will occur if the alignment is part of a chimeric alignment,
   or if the read was trimmed. When this occurs, the CIGAR for this read will
-  begin/end with a hard clip operator that will indicate the length of the excised sequence.
+  begin/end with a hard clip operator that will indicate the length of the
+  excised sequence.
   */
   union { null, string } alignedSequence = null;
 
   /**
-  The quality of the read sequence contained in this alignment record.
+  The quality of the read sequence contained in this alignment record
+  (equivalent to QUAL in SAM).
+
   `alignedSequence` and `alignedQuality` may be shorter than the full read sequence
   and quality. This will occur if the alignment is part of a chimeric alignment,
   or if the read was trimmed. When this occurs, the CIGAR for this read will


### PR DESCRIPTION
Add missing docs, increase specificity in several cases, and make some minor style tweaks.

Trying this again after merging too-soon on the original attempt, and subsequently reverting that PR. Reverts ga4gh/schemas#474