### PR TITLE
Drop "null callsets array = all calls" semantics for SearchVariants

### DIFF
--- a/src/main/resources/avro/variantmethods.avdl
+++ b/src/main/resources/avro/variantmethods.avdl
@@ -71,10 +71,9 @@ record SearchVariantsRequest {
 
   /**
   Only return variant calls which belong to call sets with these IDs.
-  If an empty array, returns variants without any call objects.
-  If null, returns all variant calls.
+  If unspecified, return all variants and no variant calls objects.
   */
-  union { null, array<string> } callSetIds = null;
+  array<string> callSetIds = [];
 
   /** Required. Only return variants on this reference. */
   string referenceName;


### PR DESCRIPTION
The issue is being forced by the [proposal to switch to proto3](https://github.com/ga4gh/schemas/pull/485); proto3 does not [disambiguate](https://developers.google.com/protocol-buffers/docs/proto3#default) between the cases of `null` and `[]`.
## Updated notes (2/11/16)

We're now simply removing the ability to retrieve all variant calls via the `callSetIds` parameter.
## Original notes

This has the side-effect that it is no longer possible to retrieve **only** the variants (sans calls). My preference is to eventually add support back in via cross-cutting response field masking for the API, e.g. via the proto3 [FieldMask](https://github.com/google/protobuf/blob/master/src/google/protobuf/field_mask.proto#L41) specification.

Alternatives considered:
1. Add another boolean field, e.g. `mask_calls` which could be passed to get the same behavior. Again, I think it makes more sense to avoid one offs and just have cross-cutting API support for field masking, but it could be acceptable in the interim, if the community feels strongly that we should not lose this functionality for an unknown duration.
2. Drop 'return all variant calls' semantics. I feel this would be surprising default behavior, since if I compose a minimal query, I expect to get almost everything back. In medium scale analysis even, e.g. thousands of callsets, having to pass all of these callset IDs will be cumbersome.
