### PR TITLE
removed tools/sphinx/generate_sphinx_docs.sh to minimize diffs with m…

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,11 +5,6 @@ target
 doc/source/schemas/*.avpr
 build
 
-# remove this if we start pushing autogen'd rst files
-# in order to build at readthedocs
-doc/source/schemas/*.rst
-
-
 #********** windows template**********
 
 # Windows image file caches

--- a/pom.xml
+++ b/pom.xml
@@ -179,7 +179,10 @@
           </execution>
         </executions>
         <configuration>
-          <executable>tools/sphinx/generate_sphinx_docs.sh</executable>
+          <executable>make</executable>
+	  <arguments>
+	    <argument>docs</argument>
+	  </arguments>
         </configuration>
       </plugin>
     </plugins>

--- a/tools/sphinx/generate_sphinx_docs.sh
+++ b/tools/sphinx/generate_sphinx_docs.sh
@@ -1,8 +1,0 @@
-#!/bin/bash
-# For backward compatibility, this script will invoke the
-# make-based doc build process
-
-root_dir=$(dirname $0)/../..
-cd $root_dir
-exec make docs
-


### PR DESCRIPTION
Minor changes to minimize non-rst diffs with master.

IMPORTANT: removes tools/sphinx/generate_sphinx_docs.sh, which is currently a wrapper around the top-level Makefile. Should be okay, but Mark may know of callers that will fail upon removal.
