### PR TITLE
Revert "Added Fragment to Reads"

### DIFF
--- a/src/main/resources/avro/reads.avdl
+++ b/src/main/resources/avro/reads.avdl
@@ -177,18 +177,6 @@ record LinearAlignment {
 }
 
 /**
-A fragment represents a contiguous stretch of a DNA or RNA molecule. Reads can
-be associated with a fragment to specify they derive from the same molecule.
-TODO: this Fragment object is essentially unused, and may be removed in a future PR.
-*/
-record Fragment {
-
-  /** The fragment ID. */
-  string id;
-
-}
-
-/**
 Each read alignment describes an alignment with additional information
 about the fragment and the read. A read alignment object is equivalent to a
 line in a SAM file.
@@ -212,12 +200,6 @@ record ReadAlignment {
   string readGroupId;
 
   // fragment attributes
-
-  /**
-  The fragment ID that this ReadAlignment belongs to.
-  TODO: this is the only reference to the Fragment object, which may be removed in a future PR.
-  */
-  string fragmentId;
 
   /** The fragment name. Equivalent to QNAME (query template name) in SAM. */
   string fragmentName;


### PR DESCRIPTION
This reverts commit 468b5af6555c2f88b66a3d0fdb36c3052ae69738.

The `Fragment` record has been checked in as an unused orphan for over a year. This resource needs more design work and supporting API methods before being proposed as an addition to the reads API.