### PR TITLE
clarify comments

### DIFF
--- a/doc/source/api/alleleAnnotations.rst
+++ b/doc/source/api/alleleAnnotations.rst
@@ -39,7 +39,7 @@ VCF's `ANN format <http://snpeff.sourceforge.net/VCFannotationformat_v1.0.pdf>`_
 | AlleleLocation      | An AlleleLocation record holds the location of an allele relative to a non-genomic coordinate system such as a CDS  |
 |                     | or protein. It holds the reference and alternate sequence where appropriate                                         |
 +---------------------+---------------------------------------------------------------------------------------------------------------------+
-| HGVSAnnotation      | A HGVSAnnotation record holds Human Genome Variation Society ( `HGVS <http://www.hgvs.org/mutnomen/recs.html>`)     |
+| HGVSAnnotation      | A HGVSAnnotation record holds Human Genome Variation Society ( `HGVS <http://www.hgvs.org/mutnomen/recs.html>`_ )   |
 |                     | descriptions of the sequence change at genomic, transcript and protein level where relevant.                        |
 +---------------------+---------------------------------------------------------------------------------------------------------------------+
 | AnalysisResult      | An AnalysisResult record holds the output of a prediction package such as SIFT on a specific allele.                |

--- a/doc/source/api/alleleAnnotations.rst
+++ b/doc/source/api/alleleAnnotations.rst
@@ -39,6 +39,9 @@ VCF's `ANN format <http://snpeff.sourceforge.net/VCFannotationformat_v1.0.pdf>`_
 | AlleleLocation      | An AlleleLocation record holds the location of an allele relative to a non-genomic coordinate system such as a CDS  |
 |                     | or protein. It holds the reference and alternate sequence where appropriate                                         |
 +---------------------+---------------------------------------------------------------------------------------------------------------------+
+| HGVSAnnotation      | A HGVSAnnotation record holds Human Genome Variation Society ( `HGVS <http://www.hgvs.org/mutnomen/recs.html>`)     |
+|                     | descriptions of the sequence change at genomic, transcript and protein level where relevant.                        |
++---------------------+---------------------------------------------------------------------------------------------------------------------+
 | AnalysisResult      | An AnalysisResult record holds the output of a prediction package such as SIFT on a specific allele.                |
 +---------------------+---------------------------------------------------------------------------------------------------------------------+
 
@@ -53,7 +56,7 @@ transcripts. The record includes:
 * The identifier of the transcript feature the variant was analysed against.
 * The alternate allele of the variant analysed. This is necessary as the current variant model supports multiple alternate alleles.
 * The predicted effects of the allele on the transcript, which should be described using `Sequence Ontology <http://www.sequenceontology.org>`_ terms.
-* Human Genome Variation Society (`HGVS <http://www.hgvs.org/mutnomen>`_ variant description nomenclature at genomic, transcript and protein level. 
+* A ``HGVSAnnotation`` record containing variant descriptions at all relevant levels. 
 * ``AlleleLocation`` records describing the changes at cDNA, CDS and protein level.
 * A set of results from prediction packages analyzing the allele impact.
 * A summary impact classification reflecting the highest impact consequence.

--- a/src/main/resources/avro/alleleAnnotationmethods.avdl
+++ b/src/main/resources/avro/alleleAnnotationmethods.avdl
@@ -76,8 +76,8 @@ record SearchVariantAnnotationsRequest {
 //  union { null, array<string> } featureIds = null;
 
   /**
-  Only return variant annotations including these effects (SO terms).
-  If null, return all variant annotations.
+  Only return variant annotations including these effects (SO terms). Exact
+  matching is required. If null, return all variant annotations.
   */
   union { null, array<org.ga4gh.models.OntologyTerm> } effects = null;
 

--- a/src/main/resources/avro/alleleAnnotationmethods.avdl
+++ b/src/main/resources/avro/alleleAnnotationmethods.avdl
@@ -77,7 +77,8 @@ record SearchVariantAnnotationsRequest {
 
   /**
   Only return variant annotations including these effects (SO terms). Exact
-  matching is required. If null, return all variant annotations.
+  matching across all fields of the OntologyTerm is required. If null, return
+  all variant annotations.
   */
   union { null, array<org.ga4gh.models.OntologyTerm> } effects = null;
 

--- a/src/main/resources/avro/alleleAnnotations.avdl
+++ b/src/main/resources/avro/alleleAnnotations.avdl
@@ -110,6 +110,10 @@ record VariantAnnotationSet {
 A HGVSAnnotation record holds Human Genome Variation Society descriptions
 of the sequence change with respect to genomic, transcript and protein
 sequences. See: http://www.hgvs.org/mutnomen/recs.html.
+Descriptions should be provided at genomic level. Descriptions at coding level
+should be provided when the allele lies within a transcript. Descriptions at
+protein level should be provided when the allele lies within the translated
+sequence or stop codon.
 */
 record HGVSAnnotation {
 

--- a/src/main/resources/avro/alleleAnnotations.avdl
+++ b/src/main/resources/avro/alleleAnnotations.avdl
@@ -110,16 +110,16 @@ record VariantAnnotationSet {
 A HGVSAnnotation record holds Human Genome Variation Society descriptions
 of the sequence change with respect to genomic, transcript and protein
 sequences. See: http://www.hgvs.org/mutnomen/recs.html.
-Descriptions should be provided at genomic level. Descriptions at coding level
-should be provided when the allele lies within a transcript. Descriptions at
-protein level should be provided when the allele lies within the translated
+Descriptions should be provided at genomic level. Descriptions at transcript
+level should be provided when the allele lies within a transcript. Descriptions
+at protein level should be provided when the allele lies within the translated
 sequence or stop codon.
 */
 record HGVSAnnotation {
 
   union { null, string } genomic = null;
 
-  union { null, string } coding = null;
+  union { null, string } transcript = null;
 
   union { null, string } protein = null;
 }


### PR DESCRIPTION
@calbach - are these comments clearer?

It would be good to do searches including child terms in the ontology later, but it may be better to add a flag to trigger this behaviour.

I'd make HGVS.genomic required, but I don't think the guidelines cover all possible variants (though they probably cover eveything the current Variant model handles). 
