### PR TITLE
Added a line so that identifiers are URL safe.

### DIFF
--- a/doc/source/api/apidesign_intro.rst
+++ b/doc/source/api/apidesign_intro.rst
@@ -24,6 +24,9 @@ Object Ids
     across server restarts -- once a user is given an ID for data
     stored on a server, the id remains valid for as long as the server
     is still storing that data
+    
+  * ids should not include characters that require URL encoding or
+    characters that are reserved for URL schemes (?, $, =, @, etc.).
 
 * Many objects, including most ‘container’ objects, also have a
   **name** field. The name is user-defined, isn’t programmatically


### PR DESCRIPTION
Although the specific identifier scheme is left up to the implementation, identifiers should be URL safe. If not, GET requests could require URL encoding. For example, we should avoid URLs that look like `http://ga4gh/referencesets/aGczNw%3D%3D` in favor of characters that are neither reserved nor need URL encoding.

```
   * ids must not include characters that require URL encoding or
     characters that are reserved for URL schemes (?, $, =, @, etc.).
```
