### PR TITLE
Invert the semantics for properPlacement to improperPlacement

### DIFF
--- a/src/main/resources/avro/reads.avdl
+++ b/src/main/resources/avro/reads.avdl
@@ -183,9 +183,9 @@ record ReadAlignment {
 
   /**
   The orientation and the distance between reads from the fragment are
-  consistent with the sequencing protocol (equivalent to SAM flag 0x2)
+  inconsistent with the sequencing protocol (inverse of SAM flag 0x2)
   */
-  union { null, boolean } properPlacement = null;
+  union { null, boolean } improperPlacement = null;
 
   /** The fragment is a PCR or optical duplicate (SAM flag 0x400). */
   union { null, boolean } duplicateFragment = null;


### PR DESCRIPTION
This is somewhat related to the move to proto (#547), as nullability has been removed for all primitive values. For example, before this proposed change, an uninitialized `Read` proto would have a value of `properPlacement=false`.

Users of Google's implementation of the v0.5.1 Reads API have expressed that this is an inconvenient and unnatural default, as many programs will filter out reads which have not been marked as 'properly placed'. For example, when generating a simple `Read` for a unit test, one would almost always want to set the `Read` to properly placed - more natural would be only to mark the read as **improperly** placed only where needed. I tend to agree, given the usage of this field in practice. This seems to be the expected state for a read - improper placement is the exception.