### PR TITLE
Remove impact and change created to createDateTime and updated to updateDateTime

### DIFF
--- a/doc/source/schemas/alleleAnnotations.rst
+++ b/doc/source/schemas/alleleAnnotations.rst
@@ -141,14 +141,14 @@ This protocol defines types used by the GA4GH Allele Annotation API.
   :field description:
     A description of the experiment.
   :type description: null|string
-  :field created:
+  :field createTime:
     The time at which this record was created. 
       Format: :ref:`ISO 8601 <metadata_date_time>`
-  :type created: string
-  :field updated:
+  :type createTime: string
+  :field updateTime:
     The time at which this record was last updated.
       Format: :ref:`ISO 8601 <metadata_date_time>`
-  :type updated: string
+  :type updateTime: string
   :field runTime:
     The time at which this experiment was performed.
       Granularity here is variable (e.g. date only).
@@ -219,14 +219,14 @@ This protocol defines types used by the GA4GH Allele Annotation API.
   :type name: null|string
   :field description:
   :type description: null|string
-  :field created:
+  :field createTime:
     The time at which this record was created. 
       Format: :ref:`ISO 8601 <metadata_date_time>`
-  :type created: null|string
-  :field updated:
+  :type createTime: null|string
+  :field updateTime:
     The time at which this record was last updated.
       Format: :ref:`ISO 8601 <metadata_date_time>`
-  :type updated: string
+  :type updateTime: string
   :field type:
     The type of analysis.
   :type type: null|string
@@ -558,9 +558,9 @@ This protocol defines types used by the GA4GH Allele Annotation API.
   :field variantAnnotationSetId:
     The ID of the variant annotation set this record belongs to.
   :type variantAnnotationSetId: string
-  :field created:
+  :field createTime:
     The :ref:`ISO 8601 <metadata_date_time>` time at which this record was created.
-  :type created: null|string
+  :type createTime: null|string
   :field transcriptEffects:
     The transcript effect annotation for the alleles of this variant. Each one
       represents the effect of a single allele on a single transcript.

--- a/doc/source/schemas/alleleAnnotations.rst
+++ b/doc/source/schemas/alleleAnnotations.rst
@@ -141,14 +141,14 @@ This protocol defines types used by the GA4GH Allele Annotation API.
   :field description:
     A description of the experiment.
   :type description: null|string
-  :field createTime:
+  :field createDateTime:
     The time at which this record was created. 
       Format: :ref:`ISO 8601 <metadata_date_time>`
-  :type createTime: string
-  :field updateTime:
+  :type createDateTime: string
+  :field updateDateTime:
     The time at which this record was last updated.
       Format: :ref:`ISO 8601 <metadata_date_time>`
-  :type updateTime: string
+  :type updateDateTime: string
   :field runTime:
     The time at which this experiment was performed.
       Granularity here is variable (e.g. date only).
@@ -219,14 +219,14 @@ This protocol defines types used by the GA4GH Allele Annotation API.
   :type name: null|string
   :field description:
   :type description: null|string
-  :field createTime:
+  :field createDateTime:
     The time at which this record was created. 
       Format: :ref:`ISO 8601 <metadata_date_time>`
-  :type createTime: null|string
-  :field updateTime:
+  :type createDateTime: null|string
+  :field updateDateTime:
     The time at which this record was last updated.
       Format: :ref:`ISO 8601 <metadata_date_time>`
-  :type updateTime: string
+  :type updateDateTime: string
   :field type:
     The type of analysis.
   :type type: null|string
@@ -464,16 +464,6 @@ This protocol defines types used by the GA4GH Allele Annotation API.
   non-genomic coordinate system such as a CDS or protein and holds the
   reference and alternate sequence where appropriate
 
-.. avro:enum:: Impact
-
-  :symbols: HIGH|MODERATE|LOW|MODIFIER
-  Impact is a simple prioritization for the effect of an allele which is used
-  in the annotation record.
-  IMPORTANT:
-   Prioritization methods are a crude estimates and are not assumed to be
-   reliable: a 'HIGH' Impact may actually not cause any disruption
-   in protein function or expression.
-
 .. avro:record:: VariantAnnotationSet
 
   :field id:
@@ -526,9 +516,6 @@ This protocol defines types used by the GA4GH Allele Annotation API.
   :field effects:
     Effect of variant on this feature
   :type effects: array<OntologyTerm>
-  :field impact:
-    Highest Impact from the predicted effects
-  :type impact: Impact
   :field hgvsAnnotation:
     Human Genome Variation Society variant descriptions
   :type hgvsAnnotation: HGVSAnnotation
@@ -558,9 +545,9 @@ This protocol defines types used by the GA4GH Allele Annotation API.
   :field variantAnnotationSetId:
     The ID of the variant annotation set this record belongs to.
   :type variantAnnotationSetId: string
-  :field createTime:
+  :field createDateTime:
     The :ref:`ISO 8601 <metadata_date_time>` time at which this record was created.
-  :type createTime: null|string
+  :type createDateTime: null|string
   :field transcriptEffects:
     The transcript effect annotation for the alleles of this variant. Each one
       represents the effect of a single allele on a single transcript.

--- a/doc/source/schemas/metadata.rst
+++ b/doc/source/schemas/metadata.rst
@@ -141,14 +141,14 @@ This protocol defines metadata used in the other GA4GH protocols.
   :field description:
     A description of the experiment.
   :type description: null|string
-  :field created:
+  :field createTime:
     The time at which this record was created. 
       Format: :ref:`ISO 8601 <metadata_date_time>`
-  :type created: string
-  :field updated:
+  :type createTime: string
+  :field updateTime:
     The time at which this record was last updated.
       Format: :ref:`ISO 8601 <metadata_date_time>`
-  :type updated: string
+  :type updateTime: string
   :field runTime:
     The time at which this experiment was performed.
       Granularity here is variable (e.g. date only).
@@ -219,14 +219,14 @@ This protocol defines metadata used in the other GA4GH protocols.
   :type name: null|string
   :field description:
   :type description: null|string
-  :field created:
+  :field createTime:
     The time at which this record was created. 
       Format: :ref:`ISO 8601 <metadata_date_time>`
-  :type created: null|string
-  :field updated:
+  :type createTime: null|string
+  :field updateTime:
     The time at which this record was last updated.
       Format: :ref:`ISO 8601 <metadata_date_time>`
-  :type updated: string
+  :type updateTime: string
   :field type:
     The type of analysis.
   :type type: null|string

--- a/doc/source/schemas/metadata.rst
+++ b/doc/source/schemas/metadata.rst
@@ -141,14 +141,14 @@ This protocol defines metadata used in the other GA4GH protocols.
   :field description:
     A description of the experiment.
   :type description: null|string
-  :field createTime:
+  :field createDateTime:
     The time at which this record was created. 
       Format: :ref:`ISO 8601 <metadata_date_time>`
-  :type createTime: string
-  :field updateTime:
+  :type createDateTime: string
+  :field updateDateTime:
     The time at which this record was last updated.
       Format: :ref:`ISO 8601 <metadata_date_time>`
-  :type updateTime: string
+  :type updateDateTime: string
   :field runTime:
     The time at which this experiment was performed.
       Granularity here is variable (e.g. date only).
@@ -219,14 +219,14 @@ This protocol defines metadata used in the other GA4GH protocols.
   :type name: null|string
   :field description:
   :type description: null|string
-  :field createTime:
+  :field createDateTime:
     The time at which this record was created. 
       Format: :ref:`ISO 8601 <metadata_date_time>`
-  :type createTime: null|string
-  :field updateTime:
+  :type createDateTime: null|string
+  :field updateDateTime:
     The time at which this record was last updated.
       Format: :ref:`ISO 8601 <metadata_date_time>`
-  :type updateTime: string
+  :type updateDateTime: string
   :field type:
     The type of analysis.
   :type type: null|string

--- a/src/main/resources/avro/alleleAnnotations.avdl
+++ b/src/main/resources/avro/alleleAnnotations.avdl
@@ -183,7 +183,7 @@ record VariantAnnotation {
   string variantAnnotationSetId;
 
   /** The :ref:`ISO 8601 <metadata_date_time>` time at which this record was created. */
-  union { null, string } created = null;
+  union { null, string } createTime = null;
 
   /**
   The transcript effect annotation for the alleles of this variant. Each one

--- a/src/main/resources/avro/alleleAnnotations.avdl
+++ b/src/main/resources/avro/alleleAnnotations.avdl
@@ -69,21 +69,6 @@ record AlleleLocation {
 }
 
 /**
-Impact is a simple prioritization for the effect of an allele which is used
-in the annotation record.
-IMPORTANT:
- Prioritization methods are a crude estimates and are not assumed to be
- reliable: a 'HIGH' Impact may actually not cause any disruption
- in protein function or expression.
-*/
-enum Impact {
- HIGH,      // Variant highly disrupts protein function
- MODERATE,  // Moderately disrupts protein function
- LOW,       // Low disruption of protein impact
- MODIFIER   // No known effect
-}
-
-/**
 A VariantAnnotationSet record groups VariantAnnotation records. It is derived
 from a VariantSet and holds information describing the software and reference
 data used in the annotation.
@@ -148,9 +133,6 @@ record TranscriptEffect {
   /** Effect of variant on this feature */
   array<OntologyTerm> effects;
 
-  /** Highest Impact from the predicted effects */
-  Impact impact;
-
   /** Human Genome Variation Society variant descriptions */
   HGVSAnnotation hgvsAnnotation;
 
@@ -183,7 +165,7 @@ record VariantAnnotation {
   string variantAnnotationSetId;
 
   /** The :ref:`ISO 8601 <metadata_date_time>` time at which this record was created. */
-  union { null, string } createTime = null;
+  union { null, string } createDateTime = null;
 
   /**
   The transcript effect annotation for the alleles of this variant. Each one

--- a/src/main/resources/avro/metadata.avdl
+++ b/src/main/resources/avro/metadata.avdl
@@ -60,13 +60,13 @@ record Experiment {
   The time at which this record was created. 
   Format: :ref:`ISO 8601 <metadata_date_time>`
   */
-  string created;
+  string createTime;
 
   /**
   The time at which this record was last updated.
   Format: :ref:`ISO 8601 <metadata_date_time>`
   */
-  string updated;
+  string updateTime;
 
   /**
   The time at which this experiment was performed.
@@ -170,13 +170,13 @@ record Analysis {
   The time at which this record was created. 
   Format: :ref:`ISO 8601 <metadata_date_time>`
   */
-  union { null, string } created = null;
+  union { null, string } createTime = null;
 
   /**
   The time at which this record was last updated.
   Format: :ref:`ISO 8601 <metadata_date_time>`
   */
-  string updated;
+  string updateTime;
 
   /** The type of analysis. */
   union { null, string } type = null;

--- a/src/main/resources/avro/metadata.avdl
+++ b/src/main/resources/avro/metadata.avdl
@@ -60,13 +60,13 @@ record Experiment {
   The time at which this record was created. 
   Format: :ref:`ISO 8601 <metadata_date_time>`
   */
-  string createTime;
+  string createDateTime;
 
   /**
   The time at which this record was last updated.
   Format: :ref:`ISO 8601 <metadata_date_time>`
   */
-  string updateTime;
+  string updateDateTime;
 
   /**
   The time at which this experiment was performed.
@@ -170,13 +170,13 @@ record Analysis {
   The time at which this record was created. 
   Format: :ref:`ISO 8601 <metadata_date_time>`
   */
-  union { null, string } createTime = null;
+  union { null, string } createDateTime = null;
 
   /**
   The time at which this record was last updated.
   Format: :ref:`ISO 8601 <metadata_date_time>`
   */
-  string updateTime;
+  string updateDateTime;
 
   /** The type of analysis. */
   union { null, string } type = null;


### PR DESCRIPTION
Keeps variant annotation records in line with latest from metadata task team. @diekhans 