### PR TITLE
SearchFeatureRequest field name fix

### DIFF
--- a/doc/source/schemas/sequenceAnnotationmethods.rst
+++ b/doc/source/schemas/sequenceAnnotationmethods.rst
@@ -425,10 +425,10 @@ Gets a list of `Feature` matching the search criteria.
     Required. The end of the window (0-based, exclusive) for which overlapping
         features should be returned.
   :type end: long
-  :field ontologyTerms:
-    If specified, this query matches only annotations which match one of the
-        provided ontology terms.
-  :type ontologyTerms: array<string>
+  :field featureTypes:
+    If specified, this query matches only annotations whose `featureType`
+        matches one of the provided ontology terms.
+  :type featureTypes: array<string>
   :field pageSize:
     Specifies the maximum number of results to return in a single page.
         If unspecified, a system default will be used.

--- a/src/main/resources/avro/sequenceAnnotationmethods.avdl
+++ b/src/main/resources/avro/sequenceAnnotationmethods.avdl
@@ -105,10 +105,10 @@ protocol SequenceAnnotationMethods {
     // TODO: To be replaced with a fully featured ontology search
     // once the Metadata definitions are rounded out.
     /**
-    If specified, this query matches only annotations which match one of the
-    provided ontology terms.
+    If specified, this query matches only annotations whose `featureType`
+    matches one of the provided ontology terms.
     */
-    array<string> ontologyTerms = [];
+    array<string> featureTypes = [];
 
     /**
     Specifies the maximum number of results to return in a single page.


### PR DESCRIPTION
Fixes #580 by renaming `ontologyTerms` to `featureTypes` in the `SearchFeatureRequest` record.