### PR TITLE
Sphinx rtd theme is not included by default

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,4 @@ humanize
 nose
 requests
 sphinx
+sphinx_rtd_theme


### PR DESCRIPTION
It is now correctly placed in the requirements.txt. Solves [this](https://travis-ci.org/ga4gh/schemas/builds/119593912) CI failure.