### PR TITLE
Change referenceName to referenceId

### DIFF
--- a/src/main/resources/avro/alleleAnnotationmethods.avdl
+++ b/src/main/resources/avro/alleleAnnotationmethods.avdl
@@ -34,20 +34,20 @@ record SearchVariantAnnotationsRequest {
   string variantAnnotationSetId;
 
   /**
-  Only return variants with reference alleles on the reference with this
-  name. One of this field or `referenceId` or `features` is required.
+  Only return annotations with reference alleles on the reference with this
+  name. One of this field or `referenceId` is required.
   (case-sensitive, exact match)
   */
   union { null, string } referenceName = null;
 
   /**
-  Only return variants with reference alleles on the reference with this
-  ID. One of this field or `referenceName` or `features` is required.
+  Only return annotations with reference alleles on the reference with this
+  ID. One of this field or `referenceName` is required.
   */
+  
   union { null, string } referenceId = null;
 
   /**
-  Required if referenceName or referenceId supplied.
   The beginning of the window (0-based, inclusive) for which variants with
   overlapping reference alleles should be returned.
   Genomic positions are non-negative integers less than reference length.
@@ -57,7 +57,7 @@ record SearchVariantAnnotationsRequest {
   long start;
 
   /**
-  Required if referenceName or referenceId supplied.
+  Required if referenceName or referenceId is supplied.
   The end of the window (0-based, exclusive) for which variants with
   overlapping reference alleles should be returned.
   */

--- a/src/main/resources/avro/readmethods.avdl
+++ b/src/main/resources/avro/readmethods.avdl
@@ -20,11 +20,18 @@ record SearchReadsRequest {
   array<string> readGroupIds;
 
   /**
-  The reference to query. Leaving blank returns results from all
-  references, including unmapped reads - this could be very large.
+  The reference to query. Omitting both referenceName and referenceId
+  returns results from all references, including unmapped reads - 
+  this could be very large.
   */
   union { null, string } referenceId = null;
 
+  /**
+  The reference to query. Omitting both referenceName and referenceId
+  returns results from all references, including unmapped reads - 
+  this could be very large.
+  */
+  union { null, string } referenceName = null;
   /**
   The start position (0-based) of this query.
   If a reference is specified, this defaults to 0.

--- a/src/main/resources/avro/sequenceAnnotationmethods.avdl
+++ b/src/main/resources/avro/sequenceAnnotationmethods.avdl
@@ -84,8 +84,15 @@ protocol SequenceAnnotationMethods {
     /**
     Only return features on the reference with this name 
     (matched to literal reference name as imported from the GFF3).
+    One of referenceName or referenceId is required.
     */
-    string referenceName;
+    union { null, string } referenceName = null;
+    
+    /**
+    Only return features on the reference with this ID
+    One of referenceName or referenceId is required.
+    */
+    union { null, string } referenceId = null;
 
     /**
     Required. The beginning of the window (0-based, inclusive) for which

--- a/src/main/resources/avro/sequenceAnnotations.avdl
+++ b/src/main/resources/avro/sequenceAnnotations.avdl
@@ -62,9 +62,8 @@ protocol SequenceAnnotations {
 
     /**
     The reference on which this feature occurs.
-    (e.g. `chr20` or `X`)
     */
-    string referenceName;
+    string referenceId;
 
     /**
     The start position at which this feature occurs (0-based).

--- a/src/main/resources/avro/variantmethods.avdl
+++ b/src/main/resources/avro/variantmethods.avdl
@@ -76,8 +76,17 @@ record SearchVariantsRequest {
   */
   union { null, array<string> } callSetIds = null;
 
-  /** Required. Only return variants on this reference. */
-  string referenceName;
+  /** 
+  Only return variants for the given reference. One of
+  referenceId or referenceName is required.
+  */
+  union { null, string } referenceId = null;
+  
+  /** 
+  Only return variants for the named reference. One of
+  referenceId or referenceName is required.
+  */
+  union { null, string } referenceName = null;
 
   /**
   Required. The beginning of the window (0-based, inclusive) for

--- a/src/main/resources/avro/variants.avdl
+++ b/src/main/resources/avro/variants.avdl
@@ -202,7 +202,7 @@ record Variant {
   The reference on which this variant occurs.
   (e.g. `chr20` or `X`)
   */
-  string referenceName;
+  string referenceId;
 
   /**
   The start position at which this variant occurs (0-based).


### PR DESCRIPTION
When performing searches on the Variants or Features endpoints the `referenceName` field allows the client to define which contig to search on. This is problematic because reference names are not required to be unique, and it is not immediately clear how to form the "referenceName" field. Is it "1" or "chr1"? This is further complicated by the fact that references can belong to multiple Reference Sets.

By using the `referenceId` in its place we ensure that each request is against a specific reference and we get better guarantees about the relationships in the data. The Reads API properly makes this distinction:

https://github.com/ga4gh/schemas/blob/master/src/main/resources/avro/readmethods.avdl#L26
