### PR TITLE
Update documentation to make it clear that Reference names are required

### DIFF
--- a/doc/source/api/apidesign_intro.rst
+++ b/doc/source/api/apidesign_intro.rst
@@ -5,8 +5,8 @@ API Design
 !!!!!!!!!!
 
 .. _apidesign_object_ids:
-Object Ids
-@@@@@@@@@@
+Object Ids and Names
+@@@@@@@@@@@@@@@@@@@@
 
 * Many objects need to be referenced by the API (e.g. a search method
   may return a list of objects) and by applications built outside the
@@ -26,10 +26,12 @@ Object Ids
     is still storing that data
 
 * Many objects, including most ‘container’ objects, also have a
-  **name** field. The name is user-defined, isn’t programmatically
-  required to be unique in any given scope (although in practice data
-  owners will often choose unique names), and is intended to be human
-  readable.  This can be thought of as a display name.
+  **name** field. The name is user-defined with the uniqueness requirements
+  vary between the various objects types.  Some containers require name
+  uniqueness within their scope, other don't enforce a uniqueness requirement.
+  Unless explicitly stated, there is no uniqueness requirement should be
+  assumed. It is intended to be human readable, although usually symbolic, not
+  a natural language description.
 
 Cross-repository data federation will need a standard way to refer to
 a data object, regardless of which repository it’s in. There is no
@@ -37,22 +39,6 @@ such standard currently, and the current API, including the id and
 name fields, isn’t sufficient.  A future API may introduce standard
 cross-repository identifiers using some combination of **content
 hashes**, **GUIDs**, and central **accession** facilities.
-
-
-ID and Name
-@@@@@@@@@@@
-
-Throughout the API objects have *IDs*. The purpose of IDs is to allow
-unique identification of all objects within a single server, such that
-no two objects in a given server have the same ID and no object has
-more than one ID.  The scope of an ID is limited to a given server and
-an ID may be an arbitrary string.
-
-A name is a user defined identifier. Names need only be uniquely
-identifying within a specific scope, for example, the names of
-sequences within a ReferenceSet must be distinct, but there might be
-two sequences named "chr1" stored in a server, each in a different
-ReferenceSet. Names may be an arbitrary string.
 
 
 Object Relationships
@@ -86,26 +72,3 @@ For the Dataset schema definition see the `Metadata schema
 <schemas/metadata.html>`_
 
     
-Unresolved Issues
-@@@@@@@@@@@@@@@@@
-
-* Is the GA4GH object design a conceptual data model that must be
-  followed or only containers for data exchange.  If they are
-  containers, where is the conceptual data model defined?
-
-* Are GA4GH objects idempotent?  In particular, can one obtain an
-  object with a subset of it's fields?
-
-* Is object life-cycle semantics in the scope of GA4GH API? Which
-  objects are immutable and which are mutable?  If objects are
-  mutable, how does one know they have changed?  How does one protect
-  against changes while using the objects over a given time-frame?
-
-* What is the definition of the wire protocol?  HTTP 1.0? Is HTTP 1.1
-  chunked encoding allowed?  What is the specification for the
-  generate JSON for a given an Avro schema?
-
-* What is the role of Avro?  Is it for documentation-only or for use
-  as an IDL?
-
-* Need overall object relationship diagram.

--- a/doc/source/schemas/references.rst
+++ b/doc/source/schemas/references.rst
@@ -118,7 +118,8 @@ Defines types used by the GA4GH References API.
       excluding all whitespace characters (this is equivalent to SQ:M5 in SAM).
   :type md5checksum: string
   :field name:
-    The name of this reference. (e.g. '22').
+    The name of this reference. (e.g. '22').  The name of the reference must be unique
+      within a ReferenceSet.
   :type name: string
   :field sourceURI:
     The URI from which the sequence was obtained. Specifies a FASTA format
@@ -149,7 +150,8 @@ Defines types used by the GA4GH References API.
   reference coordinate space for other genomic annotations. A single
   `Reference` might represent the human chromosome 1, for instance.
   
-  `Reference`s are designed to be immutable.
+  `Reference`s are designed to be immutable and maybe shared between multiple
+  `ReferenceSet`s.
 
 .. avro:record:: ReferenceSet
 

--- a/src/main/resources/avro/references.avdl
+++ b/src/main/resources/avro/references.avdl
@@ -12,7 +12,8 @@ A `Reference` is a canonical assembled contig, intended to act as a
 reference coordinate space for other genomic annotations. A single
 `Reference` might represent the human chromosome 1, for instance.
 
-`Reference`s are designed to be immutable.
+`Reference`s are designed to be immutable and maybe shared between multiple
+`ReferenceSet`s.
 */
 record Reference {
 
@@ -32,7 +33,8 @@ record Reference {
   string md5checksum;
 
   /**
-  The name of this reference. (e.g. '22').
+  The name of this reference. (e.g. '22').  The name of the reference must be unique
+  within a ReferenceSet.
   */
   string name;
 


### PR DESCRIPTION
Update documentation to make it clear that Reference names are required to be unique within a containing ReferenceSet.  Clarified introductory documentation to indicate that some containers may require name uniqueness, but that it should not be assumed unless explictly required.  Removed unresolved issues section that was left in from doc-a-thon.

This addresses  #617
