### PR TITLE
Remove dead link from appendix

### DIFF
--- a/doc/source/appendix/index.rst
+++ b/doc/source/appendix/index.rst
@@ -2,6 +2,5 @@ Appendix
 !!!!!!!!
 
 .. toctree::
-   avro_intro
    glossary
    json_intro


### PR DESCRIPTION
A later update will the remaining mentions of avro by adding generated documentation. This PR removes the avro_intro link from the appendix.