### PR TITLE
Fix UUID typo in Experiment

### DIFF
--- a/src/main/proto/ga4gh/metadata.proto
+++ b/src/main/proto/ga4gh/metadata.proto
@@ -30,7 +30,7 @@ message OntologyTerm {
 
 // An experimental preparation of a sample.
 message Experiment {
-  // The experiment UUID. This is globally unique.
+  // The experiment ID
   string id = 1;
 
   // The name of the experiment.


### PR DESCRIPTION
Removes a comment stating the Experiment ID was a UUID and was globally unique. @diekhans @jeromekelleher 