### PR TITLE
Add scripts for releasing to Maven Central (resolves #278)

### DIFF
--- a/scripts/release/README.md
+++ b/scripts/release/README.md
@@ -1,0 +1,22 @@
+Notes for release managers
+---
+
+This document describes how to make a GA4GH schemas release.
+
+Setup your environment
+1. Copy (or incorporate) the settings.xml file to ```~/.m2/settings.xml```
+2. Create a GPG key, and add it to KEYS. Review [the Maven guidelines on working
+with keys](http://central.sonatype.org/pages/working-with-pgp-signatures.html),
+as there are gotcha's related to working with primary vs. sub keys, and
+distributing your keys.
+3. Edit the username, password, etc in ```~/.m2/settings.xml```
+
+Once your environment is setup, you'll be able to do a release.
+
+Then from the project root directory, run `./scripts/release/release.sh`.
+If you have any problems, run `./scripts/release/rollback.sh`.
+
+Once you've successfully published the release, you will need to "close" and "release" it following the instructions at
+http://central.sonatype.org/pages/releasing-the-deployment.html#close-and-drop-or-release-your-staging-repository
+
+After the release is rsynced to the Maven Central repository, confirm checksums match and verify signatures.

--- a/scripts/release/release.sh
+++ b/scripts/release/release.sh
@@ -1,0 +1,33 @@
+#!/bin/sh
+
+# do we have enough arguments?
+if [ $# < 3 ]; then
+    echo "Usage:"
+    echo
+    echo "./release.sh <release version> <development version>"
+    exit 1
+fi
+
+# pick arguments
+release=$1
+devel=$2
+
+commit=$(git log --pretty=format:"%H" | head -n 1)
+echo "releasing from ${commit} on branch ${branch}"
+
+git push origin ${branch}
+
+mvn --batch-mode \
+  -P release \
+  -Dresume=false \
+  -Dtag=ga4gh-schemas-${release} \
+  -DreleaseVersion=${release} \
+  -DdevelopmentVersion=${devel} \
+  release:clean \
+  release:prepare \
+  release:perform
+
+if [ $? != 0 ]; then
+  echo "Releasing failed."
+  exit 1
+fi

--- a/scripts/release/rollback.sh
+++ b/scripts/release/rollback.sh
@@ -1,0 +1,3 @@
+#!/bin/sh
+
+mvn release:rollback

--- a/scripts/release/settings.xml
+++ b/scripts/release/settings.xml
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<settings xsi:schemaLocation="http://maven.apache.org/SETTINGS/1.1.0 http://maven.apache.org/xsd/settings-1.1.0.xsd" xmlns="http://maven.apache.org/SETTINGS/1.1.0"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+  <servers>
+    <server>
+      <id>sonatype-nexus-snapshots</id>
+      <username>@SONATYPE_USERNAME@</username>
+      <password>@SONATYPE_PASSWORD@</password>
+    </server>
+    <server>
+      <id>sonatype-nexus-staging</id>
+      <username>@SONATYPE_USERNAME@</username>
+      <password>@SONATYPE_PASSWORD@</password>
+    </server>
+  </servers>
+  <profiles>
+    <profile>
+      <id>gpg</id>
+      <properties>
+        <gpg.executable>@GPG_EXECUTABLE_PATH@</gpg.executable>
+        <gpg.passphrase>@PGP_KEY_PASSPHRASE@</gpg.passphrase>
+        <gpg.keyname>@GPG_KEY_NAME</gpg.keyname>
+      </properties>
+    </profile>
+  </profiles>
+  <activeProfiles>
+    <activeProfile>gpg</activeProfile>
+  </activeProfiles>
+</settings>


### PR DESCRIPTION
Adds a directory `scripts/release` with a script `scripts/release/release.sh` that contains scripts for pushing a release of the GA4GH schemas to Maven Central. These scripts will build the GA4GH schema artifacts, sign them, and push them to the Sonatype Nexus OSS staging repository. From there, the artifacts are uploaded to Maven Central. Additionally, a tag will be created and pushed to the Github schemas repository.

Resolves #278. CC @heuermh for review.