### PR TITLE
Fix to point at new proto schemas

### DIFF
--- a/doc/source/api/alleleAnnotations.rst
+++ b/doc/source/api/alleleAnnotations.rst
@@ -2,7 +2,7 @@
 Allele Annotation API
 !!!!!!!!!!!!!!!!!!!!!!
 
-See `Allele Annotation schema <../schemas/alleleAnnotations.html>`_ for a detailed reference.
+See `Allele Annotation schema <../schemas/allele_annotations.proto.html>`_ for a detailed reference.
 
 Introduction
 @@@@@@@@@@@@

--- a/doc/source/api/reads.rst
+++ b/doc/source/api/reads.rst
@@ -4,7 +4,7 @@
 Reads API
 !!!!!!!!!
 
-See `Reads schema <../schemas/reads.html>`_ for a detailed reference.
+See `Reads schema <../schemas/reads.proto.html>`_ for a detailed reference.
 
 
 Reads Data Model

--- a/doc/source/api/references.rst
+++ b/doc/source/api/references.rst
@@ -4,7 +4,7 @@
 References API
 !!!!!!!!!!!!!!
 
-See `References schema <../schemas/references.html>`_ for a detailed reference.
+See `References schema <../schemas/references.proto.html>`_ for a detailed reference.
 
 
 References Data Model

--- a/doc/source/api/sequence_annotations.rst
+++ b/doc/source/api/sequence_annotations.rst
@@ -3,7 +3,7 @@
 ************************
 Sequence Annotations API
 ************************
-For the Sequence Annotation schema definitions, see `Sequence Annotation schema <../schemas/sequenceAnnotations.html>`_
+For the Sequence Annotation schema definitions, see `Sequence Annotation schema <../schemas/sequence_annotations.proto.html>`_
 
 
 ------------------------

--- a/doc/source/api/variants.rst
+++ b/doc/source/api/variants.rst
@@ -4,7 +4,7 @@
 Variants API
 !!!!!!!!!!!!
 
-See `Variants schema <../schemas/variants.html>`_ for a detailed reference.
+See `Variants schema <../schemas/variants.proto.html>`_ for a detailed reference.
 
 
 Variants Data Model


### PR DESCRIPTION
The schemas generated from protoc have a different path than those previously generated by avro. This points to the proper URI. This is a part of a series of small fixes to the schema documentation.

Close #643 