### PR TITLE
Add an info field to transcript effect record

### DIFF
--- a/src/main/proto/ga4gh/allele_annotations.proto
+++ b/src/main/proto/ga4gh/allele_annotations.proto
@@ -119,6 +119,9 @@ message TranscriptEffect {
 
   // Output from prediction packages such as SIFT.
   repeated AnalysisResult analysis_results = 9;
+  
+  // Additional data in key-value pairs.
+  map<string, google.protobuf.ListValue> info = 10;
 }
 
 // A `VariantAnnotation` record represents the result of comparing a variant to


### PR DESCRIPTION
As stated in issue https://github.com/ga4gh/schemas/issues/623, the current transcript effect model loses fidelity for some information generated by SnpEff. This PR adds an `info` field in a spirit similar to the rest of the API which maintains key:[value] pairs for modeling information that do not have named fields.

This change allows a wider variety of data to be modeled and induces minimal changes to existing implementations.

Here is the mapping provided in #623 that shows which fields are not being represented. With this PR, all data presented by a `?` would be appended to the info field.

> Allele -> alternateBases
> Annotation -> effects[0].term (may we have several terms in this list?)
> Annotation_Impact -> ?
> Gene_Name -> ?
> Gene_ID -> ?
> Feature_Type -> ?
> Feature_ID -> featureId
> Transcript_BioType -> ?
> Rank -> ?
> HGVS.c / HGVS.p -> hgvsAnnotation.genomic / hgvsAnnotation.protein
> cDNA.pos / cDNA.length -> cDNALocation.start / cDNALocation.end
> CDS.pos / CDS.length -> CDSLocation.start / CDSLocation.end
> AA.pos / AA.length -> proteinLocation.start / proteinLocation.end
> Distance -> ?
> ERRORS/WARNINGS/INFO -> ?