### PR TITLE
Move Program message to metadata.proto

### DIFF
--- a/src/main/proto/ga4gh/metadata.proto
+++ b/src/main/proto/ga4gh/metadata.proto
@@ -41,3 +41,21 @@ message Dataset {
   // Additional, human-readable information on the dataset.
   string description = 3;
 }
+
+// Program can be used to track the provenance of how read data was generated.
+message Program {
+  // The command line used to run this program.
+  string command_line = 1;
+
+  // The user specified ID of the program.
+  string id = 2;
+
+  // The name of the program.
+  string name = 3;
+
+  // The ID of the program run before this one.
+  string prev_program_id = 4;
+
+  // The version of the program run.
+  string version = 5;
+}

--- a/src/main/proto/ga4gh/reads.proto
+++ b/src/main/proto/ga4gh/reads.proto
@@ -8,6 +8,7 @@ syntax = "proto3";
 package ga4gh;
 
 import "ga4gh/common.proto";
+import "ga4gh/metadata.proto";
 import "ga4gh/assay_metadata.proto";
 import "google/protobuf/struct.proto";
 
@@ -63,23 +64,6 @@ message ReadGroup {
   // Statistical data on reads in this read group.
   ReadStats stats = 11;
 
-  // Program can be used to track the provenance of how read data was generated.
-  message Program {
-    // The command line used to run this program.
-    string command_line = 1;
-
-    // The user specified ID of the program.
-    string id = 2;
-
-    // The name of the program.
-    string name = 3;
-
-    // The ID of the program run before this one.
-    string prev_program_id = 4;
-
-    // The version of the program run.
-    string version = 5;
-  }
   repeated Program programs = 12;
 
   // The ID of the reference set to which the reads in this read group are


### PR DESCRIPTION
The quantification API makes use of the Programs message for its provenance model. This PR makes the message available for reuse by moving it to `metadata.proto`. This clears the way for further work to make the provenance model consistent.