### PR TITLE
Add info field to dataset

### DIFF
--- a/src/main/proto/ga4gh/metadata.proto
+++ b/src/main/proto/ga4gh/metadata.proto
@@ -40,4 +40,7 @@ message Dataset {
 
   // Additional, human-readable information on the dataset.
   string description = 3;
+  
+  // A map of additional variant information.
+  map<string, google.protobuf.ListValue> info = 4;
 }


### PR DESCRIPTION
To help ameliorate #626 this PR extends the dataset message by adding an `info` field in a spirit similar to the rest of the API. This allows other information about a dataset not currently represented as a named field to be exchanged.