### PR TITLE
Change ontology term identifier

### DIFF
--- a/doc/source/appendix/ontologies.rst
+++ b/doc/source/appendix/ontologies.rst
@@ -9,6 +9,7 @@ Examples for OntologyTerm use
 * Info: Ontogenesis blog
 * Info: Working implementation of the GA4GH docsystem's Ontologies document
 
+.. _ciliopathy:
 
 Why should we use an ontology term?
 ===================================
@@ -38,30 +39,34 @@ What is the minimum attribute requirement for  OntologyTerm in GA4GH?
 
 Conceptually (and consistent with the metadata branch)
 
-:ontologyId:
-  required and implemented as URI
-  we assume this resolves to a meaningful document, e.g. http://purl.obolibrary.org/obo/SO_0000147
+:termId:
+  The unique identifier of the term in an ontology source. This should be a CURIE (e.g., SO:0001234), but may be an alphanumerical string (e.g., 8000/3) if no CURIE are available.
 :term:
   preferred but not required (e.g. ‘exon’); corresponds to class label
+:termUri:
+  A fully qualified URI that can be used to access details regarding the term. e.g. http://purl.bioontology.org/ontology/SNOMEDCT/76345009.
 :sourceName:
   not required since should be resolved from prefix etc., but supporting/fall-back in case of non-standard/deprecated/entropic annotations; possible use for CURIEs in compact sequence ontology implementations  (e.g. SO:0000147)
 :sourceVersion:
-  not required but good practice; if no explicit versioning, ISO8601 formatted data of retrieval should be used
+  not required but good practice; if no explicit versioning, ISO8601 formatted data of retrieval should be used.
 
 
 Ontology Selection and Overlap
 ==============================
 
 Sometimes a single ontology provides excellent coverage of a domain. For
-example the Sequence Ontology is used successfully in GFF files to annotate
-exons, introns etc. There are multiple ontologies in some domains which overlap
-in scope and content and also interoperation between ontologies. For example
-the Human Phenotype Ontology (HP) provides terms describing human phenotypes.
-Disease phenotype associations are not provided in the HP, rather as supporting
-files with common cross references such as OMIM identifiers. When selecting an
-ontology consider coverage - how much of your data is represented; structure -
-does the ontology provide structure that meets your use cases, e.g.
-contains a class ciliopathy (see above), update frequency, ability to request
+example, the Sequence Ontology is used successfully in GFF files to annotate
+exons, introns, etc. There are multiple ontologies in some domains which overlap
+in scope and content and also interoperation between ontologies.
+
+
+For example, the Human Phenotype Ontology (HP) provides terms describing human phenotypes.
+Disease phenotype associations are not provided directly by the HP, but rather as supporting
+files with common cross references such as OMIM identifiers.
+
+
+When selecting an ontology consider coverage - how much of your data is represented? Does the ontology provide structure that meets your use cases? For the case above
+contains a class ciliopathy_, update frequency, ability to request
 terms when needed, adherence to community standards  e.g. OBO foundry provides
 recommendations on versioning strategy and term deprecation.
 Note that OBO policy dictates that when the meaning of a class changes,
@@ -84,23 +89,27 @@ Examples
 Genotypic sex
 =============
 
-:ontologyId:
-	"http://purl.obolibrary.org/obo/PATO_0020001",
+:termId:
+  "PATO:0020001",
 :term:
   "male genotypic sex" ,
+:termUri:
+  "http://purl.obolibrary.org/obo/PATO_0020001"
 :sourceName:
-	"PATO Phenotypic quality",
+  "PATO Phenotypic quality",
 
 
 Sequence Ontology
 =================
 
-:ontologyId:
-  "http://purl.obolibrary.org/obo/SO_0001583",
+:termId:
+  "SO:0001583",
 :term:
-	"missense_variant",
+  "missense_variant",
+:termUri:
+  "http://purl.obolibrary.org/obo/SO_0001583",
 :sourceName:
-	"Sequence Ontology",
+  "Sequence Ontology",
 :sourceVersion:
   "release_2.5.3"
 
@@ -108,86 +117,100 @@ Sequence Ontology
 Human Phenotype ontology
 ========================
 
-:ontologyId:
-  "http://purl.obolibrary.org/obo/HP_0000819",
+:termId:
+  "HP:0000819",
 :term:
-	"Diabetes mellitus",
+  "Diabetes mellitus",
+:termUri:
+  "http://purl.obolibrary.org/obo/HP_0000819",
 :sourceName:
-	"human_phenotype Ontology",
+  "human_phenotype Ontology",
 :sourceVersion:
-	"release_Jan2016*"
+  "release_Jan2016*"
 
 ----
 
-:ontologyId:
-	"http://www.ebi.ac.uk/efo/HP_0012059",
+:termId:
+  "HP:0012059",
 :term:
-	"Lentigo maligna melanoma",
+  "Lentigo maligna melanoma",
+:termUri:
+  "http://www.ebi.ac.uk/efo/HP_0012059",
 :sourceName:
-	"human_phenotype_ontology",
+  "human_phenotype_ontology",
 :sourceVersion:
-	"2016-01-14”
+  "2016-01-14”
 
 
 Body part (Uberon)
 ==================
 
-:ontologyId:
-	"http://www.ebi.ac.uk/efo/UBERON_0003403",
+:termId:
+  "UBERON:0003403",
 :term:
-	"skin of forearm",
+  "skin of forearm",
+:termUri:
+  "http://www.ebi.ac.uk/efo/UBERON_0003403",
 :sourceName:
-	"uberon",
+  "uberon",
 :sourceVersion:
-	"2015-11-23”
+  "2015-11-23”
 
 
 Human disease ontology
 ======================
 
-:ontologyId:
-	"http://purl.obolibrary.org/obo/DOID_9351",
+:termId:
+  "DOID:9351",
 :term:
-	"diabetes mellitus",
+  "diabetes mellitus",
+:termUri:
+  "DOID_9351",
 :sourceName:
-	"disease_ontology",
+  "disease_ontology",
 :sourceVersion:
-	"2016-01-25"
+  "2016-01-25"
 
 
 Experimental factor ontology
 ============================
 
-:ontologyId:
-	"http://purl.obolibrary.org/obo/EFO_0000400",
+:termId:
+  "EFO:0000400",
 :term:
-	"diabetes mellitus",
+  "diabetes mellitus",
+:termUri:
+  "http://purl.obolibrary.org/obo/EFO_0000400",
 :sourceName:
-	"experimental_factor_ontology",
+  "experimental_factor_ontology",
 :sourceVersion:
-	"V2.68”
+  "V2.68”
 
 ----
 
-:ontologyId:
-	"http://www.ebi.ac.uk/efo/EFO_0004422",
+:termId:
+  "EFO:0004422",
 :term:
-	"exome",
+  "exome",
+:termUri:
+  "http://www.ebi.ac.uk/efo/EFO_0004422",
 :sourceName:
-	"Experimental Factor Ontology",
+  "Experimental Factor Ontology",
 :sourceVersion:
-	"release_2.68"
+  "release_2.68"
 
 
 SNOMEDCT representation of ICD-O 3 Cancer Histology
 ===================================================
 
-:ontologyId:
-	"http://purl.bioontology.org/ontology/SNMI/M-94703“
+:termId:
+  "M-94703“,
 :term:
-	"Medulloblastoma, NOS”
+  "Medulloblastoma, NOS”,
+:termUri:
+  "http://purl.bioontology.org/ontology/SNMI/M-94703",
 :sourceName:
-	"SNOMED CT model component”
+  "SNOMED CT model component”,
 :sourceVersion:
   "2016-01-28"
 
@@ -195,11 +218,13 @@ SNOMEDCT representation of ICD-O 3 Cancer Histology
 Unit Ontology
 =============
 
-:ontologyId:
-	"http://purl.obolibrary.org/obo/UO_0000016",
+:termId:
+  "UO:0000016",
 :term:
-	"millimetre",
+  "millimetre",
+:termUri:
+  "http://purl.obolibrary.org/obo/UO_0000016",
 :sourceName:
-	"Unit Ontology",
+  "Unit Ontology",
 :sourceVersion:
-	"2015-12-17"
+  "2015-12-17"

--- a/doc/source/appendix/ontologies.rst
+++ b/doc/source/appendix/ontologies.rst
@@ -9,7 +9,6 @@ Examples for OntologyTerm use
 * Info: Ontogenesis blog
 * Info: Working implementation of the GA4GH docsystem's Ontologies document
 
-.. _ciliopathy:
 
 Why should we use an ontology term?
 ===================================
@@ -40,33 +39,25 @@ What is the minimum attribute requirement for  OntologyTerm in GA4GH?
 Conceptually (and consistent with the metadata branch)
 
 :termId:
-  The unique identifier of the term in an ontology source. This should be a CURIE (e.g., SO:0001234), but may be an alphanumerical string (e.g., 8000/3) if no CURIE are available.
+  required and implemented as CURIE
+  we assume this resolves to a meaningful document, e.g. http://purl.obolibrary.org/obo/SO_0000147, using a prefix mapper, e.g. SO: <=> http://purl.obolibrary.org/obo/SO_
 :term:
   preferred but not required (e.g. ‘exon’); corresponds to class label
-:termUri:
-  A fully qualified URI that can be used to access details regarding the term. e.g. http://purl.bioontology.org/ontology/SNOMEDCT/76345009.
-:sourceName:
-  not required since should be resolved from prefix etc., but supporting/fall-back in case of non-standard/deprecated/entropic annotations; possible use for CURIEs in compact sequence ontology implementations  (e.g. SO:0000147)
-:sourceVersion:
-  not required but good practice; if no explicit versioning, ISO8601 formatted data of retrieval should be used.
 
 
 Ontology Selection and Overlap
 ==============================
 
 Sometimes a single ontology provides excellent coverage of a domain. For
-example, the Sequence Ontology is used successfully in GFF files to annotate
-exons, introns, etc. There are multiple ontologies in some domains which overlap
-in scope and content and also interoperation between ontologies.
-
-
-For example, the Human Phenotype Ontology (HP) provides terms describing human phenotypes.
-Disease phenotype associations are not provided directly by the HP, but rather as supporting
-files with common cross references such as OMIM identifiers.
-
-
-When selecting an ontology consider coverage - how much of your data is represented? Does the ontology provide structure that meets your use cases? For the case above
-contains a class ciliopathy_, update frequency, ability to request
+example the Sequence Ontology is used successfully in GFF files to annotate
+exons, introns etc. There are multiple ontologies in some domains which overlap
+in scope and content and also interoperation between ontologies. For example
+the Human Phenotype Ontology (HP) provides terms describing human phenotypes.
+Disease phenotype associations are not provided in the HP, rather as supporting
+files with common cross references such as OMIM identifiers. When selecting an
+ontology consider coverage - how much of your data is represented; structure -
+does the ontology provide structure that meets your use cases, e.g.
+contains a class ciliopathy (see above), update frequency, ability to request
 terms when needed, adherence to community standards  e.g. OBO foundry provides
 recommendations on versioning strategy and term deprecation.
 Note that OBO policy dictates that when the meaning of a class changes,
@@ -90,13 +81,10 @@ Genotypic sex
 =============
 
 :termId:
-  "PATO:0020001",
+	"PATO:0020001",
 :term:
   "male genotypic sex" ,
-:termUri:
-  "http://purl.obolibrary.org/obo/PATO_0020001"
-:sourceName:
-  "PATO Phenotypic quality",
+
 
 
 Sequence Ontology
@@ -105,13 +93,8 @@ Sequence Ontology
 :termId:
   "SO:0001583",
 :term:
-  "missense_variant",
-:termUri:
-  "http://purl.obolibrary.org/obo/SO_0001583",
-:sourceName:
-  "Sequence Ontology",
-:sourceVersion:
-  "release_2.5.3"
+	"missense_variant",
+
 
 
 Human Phenotype ontology
@@ -120,111 +103,59 @@ Human Phenotype ontology
 :termId:
   "HP:0000819",
 :term:
-  "Diabetes mellitus",
-:termUri:
-  "http://purl.obolibrary.org/obo/HP_0000819",
-:sourceName:
-  "human_phenotype Ontology",
-:sourceVersion:
-  "release_Jan2016*"
+	"Diabetes mellitus",
+
 
 ----
 
 :termId:
-  "HP:0012059",
+	"HP:0012059",
 :term:
-  "Lentigo maligna melanoma",
-:termUri:
-  "http://www.ebi.ac.uk/efo/HP_0012059",
-:sourceName:
-  "human_phenotype_ontology",
-:sourceVersion:
-  "2016-01-14”
+	"Lentigo maligna melanoma",
+
 
 
 Body part (Uberon)
 ==================
 
 :termId:
-  "UBERON:0003403",
+	"UBERON:0003403",
 :term:
-  "skin of forearm",
-:termUri:
-  "http://www.ebi.ac.uk/efo/UBERON_0003403",
-:sourceName:
-  "uberon",
-:sourceVersion:
-  "2015-11-23”
+	"skin of forearm",
 
 
 Human disease ontology
 ======================
 
 :termId:
-  "DOID:9351",
+	"DOID:9351",
 :term:
-  "diabetes mellitus",
-:termUri:
-  "DOID_9351",
-:sourceName:
-  "disease_ontology",
-:sourceVersion:
-  "2016-01-25"
+	"diabetes mellitus",
 
 
 Experimental factor ontology
 ============================
 
 :termId:
-  "EFO:0000400",
+	"EFO:0000400",
 :term:
-  "diabetes mellitus",
-:termUri:
-  "http://purl.obolibrary.org/obo/EFO_0000400",
-:sourceName:
-  "experimental_factor_ontology",
-:sourceVersion:
-  "V2.68”
+	"diabetes mellitus",
+
 
 ----
 
 :termId:
-  "EFO:0004422",
+	"EFO:0004422",
 :term:
-  "exome",
-:termUri:
-  "http://www.ebi.ac.uk/efo/EFO_0004422",
-:sourceName:
-  "Experimental Factor Ontology",
-:sourceVersion:
-  "release_2.68"
+	"exome",
 
-
-SNOMEDCT representation of ICD-O 3 Cancer Histology
-===================================================
-
-:termId:
-  "M-94703“,
-:term:
-  "Medulloblastoma, NOS”,
-:termUri:
-  "http://purl.bioontology.org/ontology/SNMI/M-94703",
-:sourceName:
-  "SNOMED CT model component”,
-:sourceVersion:
-  "2016-01-28"
 
 
 Unit Ontology
 =============
 
 :termId:
-  "UO:0000016",
+	"UO:0000016",
 :term:
-  "millimetre",
-:termUri:
-  "http://purl.obolibrary.org/obo/UO_0000016",
-:sourceName:
-  "Unit Ontology",
-:sourceVersion:
-  "2015-12-17"
+	"millimetre",
+

--- a/python/ga4gh/schemas/ga4gh/metadata_pb2.py
+++ b/python/ga4gh/schemas/ga4gh/metadata_pb2.py
@@ -20,7 +20,7 @@ DESCRIPTOR = _descriptor.FileDescriptor(
   name='ga4gh/schemas/ga4gh/metadata.proto',
   package='ga4gh.schemas.ga4gh',
   syntax='proto3',
-  serialized_pb=_b('\n\"ga4gh/schemas/ga4gh/metadata.proto\x12\x13ga4gh.schemas.ga4gh\x1a\x1cgoogle/protobuf/struct.proto\"U\n\x0cOntologyTerm\x12\n\n\x02id\x18\x01 \x01(\t\x12\x0c\n\x04term\x18\x02 \x01(\t\x12\x13\n\x0bsource_name\x18\x03 \x01(\t\x12\x16\n\x0esource_version\x18\x04 \x01(\t\"\xb7\x01\n\x07\x44\x61taset\x12\n\n\x02id\x18\x01 \x01(\t\x12\x0c\n\x04name\x18\x02 \x01(\t\x12\x13\n\x0b\x64\x65scription\x18\x03 \x01(\t\x12\x34\n\x04info\x18\x04 \x03(\x0b\x32&.ga4gh.schemas.ga4gh.Dataset.InfoEntry\x1aG\n\tInfoEntry\x12\x0b\n\x03key\x18\x01 \x01(\t\x12)\n\x05value\x18\x02 \x01(\x0b\x32\x1a.google.protobuf.ListValue:\x02\x38\x01\"c\n\x07Program\x12\x14\n\x0c\x63ommand_line\x18\x01 \x01(\t\x12\n\n\x02id\x18\x02 \x01(\t\x12\x0c\n\x04name\x18\x03 \x01(\t\x12\x17\n\x0fprev_program_id\x18\x04 \x01(\t\x12\x0f\n\x07version\x18\x05 \x01(\tb\x06proto3')
+  serialized_pb=_b('\n\"ga4gh/schemas/ga4gh/metadata.proto\x12\x13ga4gh.schemas.ga4gh\x1a\x1cgoogle/protobuf/struct.proto\"-\n\x0cOntologyTerm\x12\x0f\n\x07term_id\x18\x01 \x01(\t\x12\x0c\n\x04term\x18\x02 \x01(\t\"\xb7\x01\n\x07\x44\x61taset\x12\n\n\x02id\x18\x01 \x01(\t\x12\x0c\n\x04name\x18\x02 \x01(\t\x12\x13\n\x0b\x64\x65scription\x18\x03 \x01(\t\x12\x34\n\x04info\x18\x04 \x03(\x0b\x32&.ga4gh.schemas.ga4gh.Dataset.InfoEntry\x1aG\n\tInfoEntry\x12\x0b\n\x03key\x18\x01 \x01(\t\x12)\n\x05value\x18\x02 \x01(\x0b\x32\x1a.google.protobuf.ListValue:\x02\x38\x01\"c\n\x07Program\x12\x14\n\x0c\x63ommand_line\x18\x01 \x01(\t\x12\n\n\x02id\x18\x02 \x01(\t\x12\x0c\n\x04name\x18\x03 \x01(\t\x12\x17\n\x0fprev_program_id\x18\x04 \x01(\t\x12\x0f\n\x07version\x18\x05 \x01(\tb\x06proto3')
   ,
   dependencies=[google_dot_protobuf_dot_struct__pb2.DESCRIPTOR,])
 _sym_db.RegisterFileDescriptor(DESCRIPTOR)
@@ -36,7 +36,7 @@ _ONTOLOGYTERM = _descriptor.Descriptor(
   containing_type=None,
   fields=[
     _descriptor.FieldDescriptor(
-      name='id', full_name='ga4gh.schemas.ga4gh.OntologyTerm.id', index=0,
+      name='term_id', full_name='ga4gh.schemas.ga4gh.OntologyTerm.term_id', index=0,
       number=1, type=9, cpp_type=9, label=1,
       has_default_value=False, default_value=_b("").decode('utf-8'),
       message_type=None, enum_type=None, containing_type=None,
@@ -45,20 +45,6 @@ _ONTOLOGYTERM = _descriptor.Descriptor(
     _descriptor.FieldDescriptor(
       name='term', full_name='ga4gh.schemas.ga4gh.OntologyTerm.term', index=1,
       number=2, type=9, cpp_type=9, label=1,
-      has_default_value=False, default_value=_b("").decode('utf-8'),
-      message_type=None, enum_type=None, containing_type=None,
-      is_extension=False, extension_scope=None,
-      options=None),
-    _descriptor.FieldDescriptor(
-      name='source_name', full_name='ga4gh.schemas.ga4gh.OntologyTerm.source_name', index=2,
-      number=3, type=9, cpp_type=9, label=1,
-      has_default_value=False, default_value=_b("").decode('utf-8'),
-      message_type=None, enum_type=None, containing_type=None,
-      is_extension=False, extension_scope=None,
-      options=None),
-    _descriptor.FieldDescriptor(
-      name='source_version', full_name='ga4gh.schemas.ga4gh.OntologyTerm.source_version', index=3,
-      number=4, type=9, cpp_type=9, label=1,
       has_default_value=False, default_value=_b("").decode('utf-8'),
       message_type=None, enum_type=None, containing_type=None,
       is_extension=False, extension_scope=None,
@@ -76,7 +62,7 @@ _ONTOLOGYTERM = _descriptor.Descriptor(
   oneofs=[
   ],
   serialized_start=89,
-  serialized_end=174,
+  serialized_end=134,
 )
 
 
@@ -113,8 +99,8 @@ _DATASET_INFOENTRY = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=289,
-  serialized_end=360,
+  serialized_start=249,
+  serialized_end=320,
 )
 
 _DATASET = _descriptor.Descriptor(
@@ -164,8 +150,8 @@ _DATASET = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=177,
-  serialized_end=360,
+  serialized_start=137,
+  serialized_end=320,
 )
 
 
@@ -223,8 +209,8 @@ _PROGRAM = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=362,
-  serialized_end=461,
+  serialized_start=322,
+  serialized_end=421,
 )
 
 _DATASET_INFOENTRY.fields_by_name['value'].message_type = google_dot_protobuf_dot_struct__pb2._LISTVALUE

--- a/src/main/proto/ga4gh/metadata.proto
+++ b/src/main/proto/ga4gh/metadata.proto
@@ -13,7 +13,7 @@ message OntologyTerm {
   // scope of the schema or its resource implementation.
   string termId = 1;
 
-  // Ontology term - the label of the ontology term the id is pointing to.
+  // Ontology term - the label of the ontology term the termId is pointing to.
   string term = 2;
 
 }

--- a/src/main/proto/ga4gh/metadata.proto
+++ b/src/main/proto/ga4gh/metadata.proto
@@ -7,27 +7,15 @@ import "google/protobuf/struct.proto";
 // An ontology term describing an attribute. (e.g. the phenotype attribute
 // 'polydactyly' from HPO)
 message OntologyTerm {
-  // The unique identifier of the term in an ontology source. This should
-  // be a CURIE (e.g., SO:0001234), but may be an alphanumerical string
-  // (e.g., 8000/3) if no URI available.
-  string term_id = 5;
+  // Ontology term identifier - the CURIE for an ontology term. It
+  // differs from the standard GA4GH schema's :ref:`id <apidesign_object_ids>`
+  // in that it is a CURIE pointing to an information resource outside of the
+  // scope of the schema or its resource implementation.
+  string id = 1;
 
-  // Ontology term - the representation the `term_id` is pointing to.
+  // Ontology term - the label of the ontology term the id is pointing to.
   string term = 2;
 
-  // A fully qualified URI that can be used to access details regarding the term.
-  // e.g. http://purl.bioontology.org/ontology/SNOMEDCT/76345009.
-  string term_uri = 6;
-
-  // Ontology source name - the name of ontology from which the term is obtained
-  // e.g. 'Human Phenotype Ontology'
-  string source_name = 3;
-
-  // Ontology source version - the version of the ontology from which the
-  // OntologyTerm is obtained; e.g. 2.6.1. There is no standard for ontology
-  // versioning and some frequently released ontologies may use a datestamp, or
-  // build number.
-  string source_version = 4;
 }
 
 // A Dataset is a collection of related data of multiple types.

--- a/src/main/proto/ga4gh/metadata.proto
+++ b/src/main/proto/ga4gh/metadata.proto
@@ -7,15 +7,17 @@ import "google/protobuf/struct.proto";
 // An ontology term describing an attribute. (e.g. the phenotype attribute
 // 'polydactyly' from HPO)
 message OntologyTerm {
-  // Ontology source identifier - the identifier, a CURIE (preferred) or PURL
-  // for an ontology source e.g. http://purl.obolibrary.org/obo/hp.obo It
-  // differs from the standard GA4GH schema's :ref:`id <apidesign_object_ids>`
-  // in that it is a URI pointing to an information resource outside of the
-  // scope of the schema or its resource implementation.
-  string id = 1;
+  // The unique identifier of the term in an ontology source. This should
+  // be a CURIE (e.g., SO:0001234), but may be an alphanumerical string
+  // (e.g., 8000/3) if no URI available.
+  string term_id = 5;
 
-  // Ontology term - the representation the id is pointing to.
+  // Ontology term - the representation the `term_id` is pointing to.
   string term = 2;
+
+  // A fully qualified URI that can be used to access details regarding the term.
+  // e.g. http://purl.bioontology.org/ontology/SNOMEDCT/76345009.
+  string term_uri = 6;
 
   // Ontology source name - the name of ontology from which the term is obtained
   // e.g. 'Human Phenotype Ontology'

--- a/src/main/proto/ga4gh/metadata.proto
+++ b/src/main/proto/ga4gh/metadata.proto
@@ -11,7 +11,7 @@ message OntologyTerm {
   // differs from the standard GA4GH schema's :ref:`id <apidesign_object_ids>`
   // in that it is a CURIE pointing to an information resource outside of the
   // scope of the schema or its resource implementation.
-  string id = 1;
+  string termId = 1;
 
   // Ontology term - the label of the ontology term the id is pointing to.
   string term = 2;

--- a/src/main/proto/ga4gh/metadata.proto
+++ b/src/main/proto/ga4gh/metadata.proto
@@ -11,7 +11,7 @@ message OntologyTerm {
   // differs from the standard GA4GH schema's :ref:`id <apidesign_object_ids>`
   // in that it is a CURIE pointing to an information resource outside of the
   // scope of the schema or its resource implementation.
-  string termId = 1;
+  string term_id = 1;
 
   // Ontology term - the label of the ontology term the termId is pointing to.
   string term = 2;


### PR DESCRIPTION
Ontology terms had an ambigious 'id' field and description. This PR renames the field to term_id to remove the confusion over the role of the field, as well as improves the comment for its proper use. A field 'term_uri' has been added that allows one to specify the full URI for a term if it is available.

Closes #621 #165 