### PR TITLE
Add Biosample ID to quantification

### DIFF
--- a/src/main/proto/ga4gh/rna_quantification.proto
+++ b/src/main/proto/ga4gh/rna_quantification.proto
@@ -46,6 +46,9 @@ message RnaQuantification {
  
   // Name
   string name = 2;
+  
+  // Biosample ID
+  string bio_sample_id = 8;
 
   // Description
   string description = 3;

--- a/src/main/proto/ga4gh/rna_quantification_service.proto
+++ b/src/main/proto/ga4gh/rna_quantification_service.proto
@@ -93,6 +93,9 @@ message SearchRnaQuantificationsRequest {
   // Return only Rna Quantifications which belong to this set.
   // Must be specified.
   string rna_quantification_set_id = 1;
+  
+  // Return only RNA quantifications regarding the specified biosample. Optional.
+  string bio_sample_id = 4;
 
   // Specifies the maximum number of results to return in a single page.
   // If unspecified, a system default will be used.


### PR DESCRIPTION
This PR allows one to filter RNA quantifications by bio_sample_id.

Currently, RNA quantifications are not given a `bio_sample_id` field. RNA quantifications can be optionally associated with read group IDs, which in turn are tagged by biosample. This addition allows one to query RNA quantifications by `bio_sample_id` directly, retaining the redundancy in read groups. This is done by adding it to the quantification message and search request. @saupchurch 