### PR TITLE
Biosample sample characteristics

### DIFF
--- a/doc/source/api/biometadata.rst
+++ b/doc/source/api/biometadata.rst
@@ -37,7 +37,7 @@ Attribute             Notes
 *name*                * a human readable object label/identifier
                       * not to be used for referencing
 *description*         * additional, unstructured information about this BioSample
-*disease*             * OntologyTerm annotating the disease of the sample
+*sample_characteristics*             * List of OntologyTerm objects annotating the biological characteristics (e.g. anatomic location, patho-histology) of the sample
 *individualId*        * the *id* of the *Individual* this BioSample was derived from
 *created*             * the time the record was created, in ISO8601
 *updated*             * the time the record was updated, in ISO8601

--- a/src/main/proto/ga4gh/bio_metadata.proto
+++ b/src/main/proto/ga4gh/bio_metadata.proto
@@ -76,8 +76,15 @@ message BioSample {
   // The "description" attributes should not contain any structured data.
   string description = 4;
 
-  // OntologyTerm describing the primary disease associated with this BioSample.
-  OntologyTerm disease = 5;
+  // Zero or more OntologyTerm objects describing characteristics of this
+  // Biosample. These should not be used to annotate general characteristics
+  // of the individual this Biosample was derived from.
+  // Example: In a Biosample comprised of leukemic blasts from an individual
+  // with Down syndrome (DS) and Acute Myeloid Leukemia,
+  // sample_characteristics would contain OntologyTerm objects referring to
+  // the tissue type (e.g. bone marrow) and the type of leukemia,
+  // but not the diagnosis of DS
+  repeated OntologyTerm sample_characteristics = 5;
 
   // The :ref:`ISO 8601<metadata_date_time>` time at which this BioSample record
   // was created.


### PR DESCRIPTION
Reopened from #710 to remove extraneous commits. @mbaudis if you're happy with it you can close the other.

> This PR addresses the need for a different structure and naming of the Biosample.disease attribute:

>there has been consensus in the metadata task team that an attribute name of disease is misleading in the context of Biosample and should be reserved for the individual object level
a Biosample can use a number of ontologies, e.g. for patho-histology, anatomic location, tissue type ...; see also the discussion at #707
> The renaming to sample_characteristics is in line with the use e.g. at GEO; however, the sample_ prefix may not be strictly necessary. Alternatives welcome.