### PR TITLE
Allow descriptor type 12

### DIFF
--- a/tools/sphinx/protobuf-json-docs.py
+++ b/tools/sphinx/protobuf-json-docs.py
@@ -121,7 +121,7 @@ def traverse(proto_file):
             place["trailing_comments"] = loc.trailing_comments
     
     # Only message, services, enums, extensions, options
-    if set(tree.keys()).difference(set([4, 5, 6, 7, 8])) != set():
+    if set(tree.keys()).difference(set([4, 5, 6, 7, 8, 12])) != set():
         raise Exception, tree
 
     return {"types":


### PR DESCRIPTION
The doc generation process was broken due to an uncaught exception.

Fixes the currently breaking build. @dcolligan @bwalsh @saupchurch 