### PR TITLE
time format fixes

### DIFF
--- a/src/main/proto/ga4gh/reads.proto
+++ b/src/main/proto/ga4gh/reads.proto
@@ -53,13 +53,11 @@ message ReadGroup {
   // The predicted insert size of this read group.
   int32 predicted_insert_size = 8;
 
-  // The time at which this read group was created in milliseconds from the
-  // epoch.
-  int64 created = 9;
+  // The time at which this read group was created in ISO 8601.
+  string created = 9;
 
-  // The time at which this read group was last updated in milliseconds
-  // from the epoch.
-  int64 updated = 10;
+  // The time at which this read group was last updated in ISO 8601.
+  string updated = 10;
 
   // Statistical data on reads in this read group.
   ReadStats stats = 11;

--- a/src/main/proto/ga4gh/variants.proto
+++ b/src/main/proto/ga4gh/variants.proto
@@ -74,12 +74,11 @@ message CallSet {
   // The IDs of the variant sets this call set has calls in.
   repeated string variant_set_ids = 4;
 
-  // The date this call set was created in milliseconds from the epoch.
-  int64 created = 5;
+  // The date this call set was created in ISO 8601.
+  string created = 5;
 
-  // The time at which this call set was last updated in
-  // milliseconds from the epoch.
-  int64 updated = 6;
+  // The time at which this call set was last updated in ISO 8601.
+  string updated = 6;
 
   // A map of additional call set information.
   map<string, google.protobuf.ListValue> info = 7;
@@ -151,12 +150,11 @@ message Variant {
   // Names for the variant, for example a RefSNP ID.
   repeated string names = 3;
 
-  // The date this variant was created in milliseconds from the epoch.
-  int64 created = 4;
+  // The date this variant was created in ISO 8601.
+  string created = 4;
 
-  // The time at which this variant was last updated in
-  // milliseconds from the epoch.
-  int64 updated = 5;
+  // The time at which this variant was last updated in ISO 8601.
+  string updated = 5;
 
   // The reference on which this variant occurs.
   // (e.g. `chr20` or `X`)


### PR DESCRIPTION
Fixing lurking “milliseconds from epoch” times (has been done before, but somehow crept in again due to branching madness)
