### PR TITLE
Add release notes

### DIFF
--- a/doc/release-notes.md
+++ b/doc/release-notes.md
@@ -1,14 +1,26 @@
+# Schema Release `v0.6.0.a8` 
+
+Changes to `ga4gh/schemas` `master` branch since version `0.6.0a7` (Aug 19, 2016)
+
+* Introduced G2P API endpoints including the following:
+  * POST `/phenotypeassociationsets/search`
+  * POST `/phenotypes/search`
+  * POST `/featurephenotypeassociations/search`
+* Add biometadata to RNA quantifications
+* Add protobuf based HTTP annotations
+
 # Schema Release `v0.6.0.a7` 
 
 Changes to `ga4gh/schemas` `master` branch since version `0.6.0a6` (Jul 25, 2016)
 
 Introduced RNA API endpoints including the following:
-'POST /rnaquantificationsets/search'
-'GET /rnaquantificationsets/{id}'
-'POST /rnaquantifications/search'
-'GET /rnaquantifications/{id}'
-'POST /expressionlevels/search'
-'GET /expressionlevels/{id}'
+
+* POST `/rnaquantificationsets/search`
+* GET `/rnaquantificationsets/{id}`
+* POST `/rnaquantifications/search`
+* GET `/rnaquantifications/{id}`
+* POST `/expressionlevels/search`
+* GET `/expressionlevels/{id}`
 
 # Schema Release `v0.6.0.a6` 
 


### PR DESCRIPTION
Changes to `ga4gh/schemas` `master` branch since version `0.6.0a7` (Aug 19, 2016)

 * Introduced G2P API endpoints including the following:
  * POST `/phenotypeassociationsets/search`
  * POST `/phenotypes/search`
  * POST `/featurephenotypeassociations/search`
  * Add biometadata to RNA quantifications
  * Add protobuf based HTTP annotations

Improve display of older note slightly.  close #718 