### PR TITLE
Remove sphinx from maven package

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -176,7 +176,7 @@
         </configuration>
         <executions>
           <execution>
-            <phase>package</phase>
+            <phase>site</phase>
             <goals>
               <goal>generate</goal>
             </goals>


### PR DESCRIPTION
The doc generation process currently relies on a shell installation of `protoc`. This PR moves the doc generation from the `mvn package` to `mvn site`, as not all build environments have this available. 

https://github.com/ga4gh/compliance/issues/224