### PR TITLE
Fix get variant annotations path typo

### DIFF
--- a/src/main/proto/ga4gh/allele_annotation_service.proto
+++ b/src/main/proto/ga4gh/allele_annotation_service.proto
@@ -52,7 +52,7 @@ service AlleleAnnotationService {
   rpc GetVariantAnnotationSet(GetVariantAnnotationSetRequest)
     returns (VariantAnnotationSet) {
       option (google.api.http) = {
-        get: "/v0.6.0a8/variantannotationset/{variant_annotation_set_id}"
+        get: "/v0.6.0a8/variantannotationsets/{variant_annotation_set_id}"
       };
     };
 


### PR DESCRIPTION
There was a missing `s` in the options for the Get Variant Annotation Set By ID endpoint.
