### PR TITLE
Fix make docs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,5 +16,6 @@ before_install:
     - export PATH=/tmp/proto3.1.0/bin:$PATH
     - pip install -r python/dev-requirements.txt
 script:
+    - make docs
     - flake8 scripts tests
     - python -mnose tests

--- a/README.rst
+++ b/README.rst
@@ -103,3 +103,5 @@ See the `LICENSE <LICENSE>`__
 			  :target: https://travis-ci.org/ga4gh/schemas
 .. |Docs| image:: https://readthedocs.org/projects/ga4gh-schemas/badge/
 		  :target: http://ga4gh-schemas.readthedocs.org
+..|PyPi Release| image:: https://img.shields.io/pypi/v/ga4gh-schemas.svg
+			  :target: https://pypi.python.org/pypi/ga4gh-schemas/

--- a/README.rst
+++ b/README.rst
@@ -5,7 +5,7 @@
 Schemas for the Data Working Group
 !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
 
-|Build Status| |Docs|
+|Build Status| |Docs| |PyPi Release|
 
 The `Global Alliance for Genomics and Health
 <http://genomicsandhealth.org/>`__ is an international coalition,
@@ -103,5 +103,5 @@ See the `LICENSE <LICENSE>`__
 			  :target: https://travis-ci.org/ga4gh/schemas
 .. |Docs| image:: https://readthedocs.org/projects/ga4gh-schemas/badge/
 		  :target: http://ga4gh-schemas.readthedocs.org
-..|PyPi Release| image:: https://img.shields.io/pypi/v/ga4gh-schemas.svg
+.. |PyPi Release| image:: https://img.shields.io/pypi/v/ga4gh-schemas.svg
 			  :target: https://pypi.python.org/pypi/ga4gh-schemas/

--- a/doc/source/environment.yml
+++ b/doc/source/environment.yml
@@ -1,7 +1,7 @@
 channels:
 - ioos
 dependencies:
-- protobuf=3.1.0.post1=py27_0
+- protobuf=3.0.0=py27_0
 - openssl=1.0.2h=1
 - pip=8.1.2=py27_0
 - python=2.7.11=0

--- a/doc/source/environment.yml
+++ b/doc/source/environment.yml
@@ -1,7 +1,7 @@
 channels:
 - ioos
 dependencies:
-- protobuf=3.0.0=py27_0
+- protobuf=3.1.0.post1=py27_0
 - openssl=1.0.2h=1
 - pip=8.1.2=py27_0
 - python=2.7.11=0
@@ -13,4 +13,4 @@ dependencies:
 - wheel=0.29.0=py27_0
 - zlib=1.2.8=3
 - pip:
-    - protobuf==3.0.0b3
+    - protobuf==3.1.0.post1

--- a/doc/source/environment.yml
+++ b/doc/source/environment.yml
@@ -14,3 +14,4 @@ dependencies:
 - zlib=1.2.8=3
 - pip:
     - protobuf==3.1.0.post1
+    - sphinx==1.5.1

--- a/python/dev-requirements.txt
+++ b/python/dev-requirements.txt
@@ -10,5 +10,5 @@ flake8
 humanize
 nose
 requests
-sphinx==1.4.6
+sphinx==1.5.1
 sphinx_rtd_theme


### PR DESCRIPTION
[A bug in docutils](https://github.com/sphinx-doc/sphinx/issues/3212) was causing our documentation generation process to fail. This updates the sphinx requirement to 1.5.1, updates the environment.yml to use the latest protobuf, and adds `make docs` to the Travis.

Note that readthedocs appears to be having this same error. Changing the dev-requirements fixed it for a local build, but I will leave #757 open until RTD is working as well.