### PR TITLE
Fix typo

### DIFF
--- a/python/README.pypi.rst
+++ b/python/README.pypi.rst
@@ -5,8 +5,9 @@
 GA4GH Schemas
 =============
 
-This is the GA4GH schemas compiled as Protocol Buffers descriptors. It can be used 
-describe and serialize genomics data using a standard interchange format.
+This is the GA4GH schemas compiled as `Protocol Buffers <https://developers.google.com/protocol-buffers/>`_
+descriptors. It can be used to describe and serialize genomics data using a
+standard interchange format.
 
 .. code-block:: python
 

--- a/python/README.rst
+++ b/python/README.rst
@@ -6,7 +6,7 @@ GA4GH Schemas Python
 ====================
 
 This is the GA4GH schemas compiled as Protocol Buffers descriptors. It can be used 
-describe and serialize genomics data using a standard interchange format.
+to describe and serialize genomics data using a standard interchange format.
 
 You can install the schemas using `pip install ga4gh-schemas`.
 


### PR DESCRIPTION
Protocol buffers can be used "to" describe genomics data. :+1: 